### PR TITLE
feat: add support for Utf8View and BinaryView data types

### DIFF
--- a/remote-table/src/connection/mysql.rs
+++ b/remote-table/src/connection/mysql.rs
@@ -8,11 +8,12 @@ use async_stream::stream;
 use bigdecimal::{BigDecimal, num_bigint};
 use chrono::Timelike;
 use datafusion::arrow::array::{
-    ArrayRef, BinaryBuilder, Date32Builder, Decimal128Builder, Decimal256Builder, Float32Builder,
-    Float64Builder, Int8Builder, Int16Builder, Int32Builder, Int64Builder, LargeBinaryBuilder,
-    LargeStringBuilder, RecordBatch, RecordBatchOptions, StringBuilder, Time32SecondBuilder,
-    Time64NanosecondBuilder, TimestampMicrosecondBuilder, UInt8Builder, UInt16Builder,
-    UInt32Builder, UInt64Builder, make_builder,
+    ArrayRef, BinaryBuilder, BinaryViewBuilder, Date32Builder, Decimal128Builder,
+    Decimal256Builder, Float32Builder, Float64Builder, Int8Builder, Int16Builder, Int32Builder,
+    Int64Builder, LargeBinaryBuilder, LargeStringBuilder, RecordBatch, RecordBatchOptions,
+    StringBuilder, StringViewBuilder, Time32SecondBuilder, Time64NanosecondBuilder,
+    TimestampMicrosecondBuilder, UInt8Builder, UInt16Builder, UInt32Builder, UInt64Builder,
+    make_builder,
 };
 use datafusion::arrow::datatypes::{DataType, Date32Type, SchemaRef, TimeUnit, i256};
 use datafusion::common::{DataFusionError, project_schema};
@@ -560,6 +561,18 @@ fn rows_to_batch(
                         just_return
                     );
                 }
+                DataType::Utf8View => {
+                    handle_primitive_type!(
+                        builder,
+                        field,
+                        col,
+                        StringViewBuilder,
+                        String,
+                        row,
+                        idx,
+                        just_return
+                    );
+                }
                 DataType::Binary => {
                     handle_primitive_type!(
                         builder,
@@ -578,6 +591,18 @@ fn rows_to_batch(
                         field,
                         col,
                         LargeBinaryBuilder,
+                        Vec<u8>,
+                        row,
+                        idx,
+                        just_return
+                    );
+                }
+                DataType::BinaryView => {
+                    handle_primitive_type!(
+                        builder,
+                        field,
+                        col,
+                        BinaryViewBuilder,
                         Vec<u8>,
                         row,
                         idx,

--- a/remote-table/src/connection/oracle.rs
+++ b/remote-table/src/connection/oracle.rs
@@ -6,10 +6,10 @@ use crate::{
 };
 use bb8_oracle::OracleConnectionManager;
 use datafusion::arrow::array::{
-    ArrayRef, BinaryBuilder, BooleanBuilder, Date64Builder, Decimal128Builder, Float32Builder,
-    Float64Builder, Int16Builder, Int32Builder, Int64Builder, LargeBinaryBuilder,
-    LargeStringBuilder, RecordBatch, RecordBatchOptions, StringBuilder, StructBuilder,
-    TimestampNanosecondBuilder, TimestampSecondBuilder, make_builder,
+    ArrayRef, BinaryBuilder, BinaryViewBuilder, BooleanBuilder, Date64Builder, Decimal128Builder,
+    Float32Builder, Float64Builder, Int16Builder, Int32Builder, Int64Builder, LargeBinaryBuilder,
+    LargeStringBuilder, RecordBatch, RecordBatchOptions, StringBuilder, StringViewBuilder,
+    StructBuilder, TimestampNanosecondBuilder, TimestampSecondBuilder, make_builder,
 };
 use datafusion::arrow::datatypes::{DataType, Fields, SchemaRef, TimeUnit};
 use datafusion::common::{DataFusionError, project_schema};
@@ -316,6 +316,18 @@ fn rows_to_batch(
                         just_return
                     );
                 }
+                DataType::Utf8View => {
+                    handle_primitive_type!(
+                        builder,
+                        field,
+                        col,
+                        StringViewBuilder,
+                        String,
+                        row,
+                        idx,
+                        just_return
+                    );
+                }
                 DataType::Decimal128(_precision, scale) => {
                     handle_primitive_type!(
                         builder,
@@ -412,6 +424,18 @@ fn rows_to_batch(
                         field,
                         col,
                         LargeBinaryBuilder,
+                        Vec<u8>,
+                        row,
+                        idx,
+                        just_return
+                    );
+                }
+                DataType::BinaryView => {
+                    handle_primitive_type!(
+                        builder,
+                        field,
+                        col,
+                        BinaryViewBuilder,
                         Vec<u8>,
                         row,
                         idx,

--- a/remote-table/src/connection/sqlite.rs
+++ b/remote-table/src/connection/sqlite.rs
@@ -5,8 +5,9 @@ use crate::{
     literalize_array,
 };
 use datafusion::arrow::array::{
-    ArrayBuilder, ArrayRef, BinaryBuilder, Float64Builder, Int32Builder, Int64Builder, NullBuilder,
-    RecordBatch, RecordBatchOptions, StringBuilder, make_builder,
+    ArrayBuilder, ArrayRef, BinaryBuilder, BinaryViewBuilder, Float64Builder, Int32Builder,
+    Int64Builder, NullBuilder, RecordBatch, RecordBatchOptions, StringBuilder, StringViewBuilder,
+    make_builder,
 };
 use datafusion::arrow::datatypes::{DataType, SchemaRef};
 use datafusion::common::{DataFusionError, project_schema};
@@ -567,8 +568,14 @@ fn append_rows_to_array_builders(
             DataType::Utf8 => {
                 handle_primitive_type!(builder, field, col, StringBuilder, String, row, idx);
             }
+            DataType::Utf8View => {
+                handle_primitive_type!(builder, field, col, StringViewBuilder, String, row, idx);
+            }
             DataType::Binary => {
                 handle_primitive_type!(builder, field, col, BinaryBuilder, Vec<u8>, row, idx);
+            }
+            DataType::BinaryView => {
+                handle_primitive_type!(builder, field, col, BinaryViewBuilder, Vec<u8>, row, idx);
             }
             _ => {
                 return Err(DataFusionError::NotImplemented(format!(


### PR DESCRIPTION
Add support for Arrow `Utf8View` and `BinaryView` data types across all database connectors:

- **DM (ODBC)**: buffer.rs and row.rs
- **MySQL**
- **Oracle**
- **PostgreSQL** (including XML/JSON special handling)
- **SQLite**

These view types are more memory-efficient alternatives to `Utf8`/`Binary` for string and binary data.