### PR TITLE
refactor: remove as_any from custom trait objects

### DIFF
--- a/benchmarks/src/bin/postgres.rs
+++ b/benchmarks/src/bin/postgres.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let conn = pool.get().await?;
 
     let table_name = "pg_bench";
-    let pg_conn = conn.as_any().downcast_ref::<PostgresConnection>().unwrap();
+    let pg_conn = conn.downcast_ref::<PostgresConnection>().unwrap();
     pg_conn
         .conn
         .batch_execute(&create_table_sql(table_name))

--- a/integration-tests/tests/common.rs
+++ b/integration-tests/tests/common.rs
@@ -17,7 +17,6 @@ use datafusion_remote_table::{
     Transform, TransformArgs, TransformCodec, transform_schema,
 };
 use integration_tests::{init_env_logger, setup_sqlite_db};
-use std::any::Any;
 use std::sync::Arc;
 
 #[rstest::rstest]
@@ -113,7 +112,7 @@ pub struct MyTransformCodec {}
 
 impl TransformCodec for MyTransformCodec {
     fn try_encode(&self, value: &dyn Transform) -> Result<Vec<u8>, DataFusionError> {
-        if value.as_any().downcast_ref::<MyTransform>().is_some() {
+        if value.downcast_ref::<MyTransform>().is_some() {
             Ok("MyTransform".as_bytes().to_vec())
         } else {
             Err(DataFusionError::Internal(
@@ -137,10 +136,6 @@ impl TransformCodec for MyTransformCodec {
 pub struct MyTransform {}
 
 impl Transform for MyTransform {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn transform(
         &self,
         batch: RecordBatch,
@@ -293,10 +288,6 @@ async fn transform_adding_field(
     struct MyTransform;
 
     impl Transform for MyTransform {
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
-
         fn transform(
             &self,
             batch: RecordBatch,
@@ -374,10 +365,6 @@ async fn transform_removing_field(
     struct MyTransform;
 
     impl Transform for MyTransform {
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
-
         fn transform(
             &self,
             batch: RecordBatch,

--- a/remote-table/src/codec.rs
+++ b/remote-table/src/codec.rs
@@ -35,7 +35,7 @@ const DEFAULT_TRANSFORM_ID: &str = "__default";
 
 impl TransformCodec for DefaultTransformCodec {
     fn try_encode(&self, value: &dyn Transform) -> DFResult<Vec<u8>> {
-        if value.as_any().is::<DefaultTransform>() {
+        if value.is::<DefaultTransform>() {
             Ok(DEFAULT_TRANSFORM_ID.as_bytes().to_vec())
         } else {
             Err(DataFusionError::Execution(format!(
@@ -67,7 +67,7 @@ const DEFAULT_LITERALIZE_ID: &str = "__default";
 
 impl LiteralizeCodec for DefaultLiteralizeCodec {
     fn try_encode(&self, value: &dyn Literalize) -> DFResult<Vec<u8>> {
-        if value.as_any().is::<DefaultLiteralizer>() {
+        if value.is::<DefaultLiteralizer>() {
             Ok(DEFAULT_LITERALIZE_ID.as_bytes().to_vec())
         } else {
             Err(DataFusionError::Execution(format!(
@@ -202,7 +202,7 @@ impl PhysicalExtensionCodec for RemotePhysicalCodec {
 
     fn try_encode(&self, node: Arc<dyn ExecutionPlan>, buf: &mut Vec<u8>) -> DFResult<()> {
         if let Some(exec) = node.as_any().downcast_ref::<RemoteTableScanExec>() {
-            let serialized_transform = if exec.transform.as_any().is::<DefaultTransform>() {
+            let serialized_transform = if exec.transform.is::<DefaultTransform>() {
                 DefaultTransformCodec {}.try_encode(exec.transform.as_ref())?
             } else {
                 let bytes = self.transform_codec.try_encode(exec.transform.as_ref())?;

--- a/remote-table/src/connection/dm/mod.rs
+++ b/remote-table/src/connection/dm/mod.rs
@@ -17,7 +17,6 @@ use log::debug;
 use odbc_api::buffers::ColumnarAnyBuffer;
 use odbc_api::handles::StatementImpl;
 use odbc_api::{Cursor, CursorImpl, Environment, ResultSetMetadata};
-use std::any::Any;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::runtime::Handle;
@@ -89,10 +88,6 @@ impl Drop for DmConnection {
 
 #[async_trait::async_trait]
 impl Connection for DmConnection {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     async fn infer_schema(&self, source: &RemoteSource) -> DFResult<RemoteSchemaRef> {
         let sql = RemoteDbType::Dm.limit_1_query_if_possible(source);
         let conn = self.conn.lock().await;

--- a/remote-table/src/connection/mod.rs
+++ b/remote-table/src/connection/mod.rs
@@ -51,9 +51,7 @@ pub struct PoolState {
 }
 
 #[async_trait::async_trait]
-pub trait Connection: Debug + Send + Sync {
-    fn as_any(&self) -> &dyn Any;
-
+pub trait Connection: Debug + Send + Sync + Any {
     async fn infer_schema(&self, source: &RemoteSource) -> DFResult<RemoteSchemaRef>;
 
     async fn query(
@@ -74,6 +72,16 @@ pub trait Connection: Debug + Send + Sync {
         remote_schema: RemoteSchemaRef,
         batch: RecordBatch,
     ) -> DFResult<usize>;
+}
+
+impl dyn Connection {
+    pub fn is<T: Connection>(&self) -> bool {
+        (self as &dyn Any).is::<T>()
+    }
+
+    pub fn downcast_ref<T: Connection>(&self) -> Option<&T> {
+        (self as &dyn Any).downcast_ref::<T>()
+    }
 }
 
 #[allow(unused_variables)]

--- a/remote-table/src/connection/mysql.rs
+++ b/remote-table/src/connection/mysql.rs
@@ -25,7 +25,6 @@ use log::debug;
 use mysql_async::consts::{ColumnFlags, ColumnType};
 use mysql_async::prelude::Queryable;
 use mysql_async::{Column, FromValueError, Row, Value};
-use std::any::Any;
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -81,10 +80,6 @@ pub struct MysqlConnection {
 
 #[async_trait::async_trait]
 impl Connection for MysqlConnection {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     async fn infer_schema(&self, source: &RemoteSource) -> DFResult<RemoteSchemaRef> {
         let sql = RemoteDbType::Mysql.limit_1_query_if_possible(source);
         let mut conn = self.conn.lock().await;
@@ -482,15 +477,14 @@ fn rows_to_batch(
                 DataType::Timestamp(TimeUnit::Microsecond, tz_opt) => {
                     match tz_opt {
                         None => {}
-                        Some(tz) => {
-                            if !tz.eq_ignore_ascii_case("utc") {
-                                return Err(DataFusionError::NotImplemented(format!(
-                                    "Unsupported data type {:?} for col: {:?}",
-                                    field.data_type(),
-                                    col
-                                )));
-                            }
+                        Some(tz) if !tz.eq_ignore_ascii_case("utc") => {
+                            return Err(DataFusionError::NotImplemented(format!(
+                                "Unsupported data type {:?} for col: {:?}",
+                                field.data_type(),
+                                col
+                            )));
                         }
+                        Some(_) => {}
                     }
                     handle_primitive_type!(
                         builder,

--- a/remote-table/src/connection/oracle.rs
+++ b/remote-table/src/connection/oracle.rs
@@ -19,7 +19,6 @@ use futures::StreamExt;
 use log::debug;
 use oracle::sql_type::{Object, OracleType as ColumnType};
 use oracle::{Connector, Row};
-use std::any::Any;
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -77,10 +76,6 @@ pub struct OracleConnection {
 
 #[async_trait::async_trait]
 impl Connection for OracleConnection {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     async fn infer_schema(&self, source: &RemoteSource) -> DFResult<RemoteSchemaRef> {
         let sql = RemoteDbType::Oracle.limit_1_query_if_possible(source);
         let result_set = self.conn.query(&sql, &[]).map_err(|e| {

--- a/remote-table/src/connection/postgres.rs
+++ b/remote-table/src/connection/postgres.rs
@@ -31,7 +31,6 @@ use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
 use futures::StreamExt;
 use log::debug;
 use num_bigint::{BigInt, Sign};
-use std::any::Any;
 use std::string::ToString;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -103,10 +102,6 @@ pub struct PostgresConnection {
 
 #[async_trait::async_trait]
 impl Connection for PostgresConnection {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     async fn infer_schema(&self, source: &RemoteSource) -> DFResult<RemoteSchemaRef> {
         match source {
             RemoteSource::Table(table) => {

--- a/remote-table/src/connection/sqlite.rs
+++ b/remote-table/src/connection/sqlite.rs
@@ -17,7 +17,6 @@ use itertools::Itertools;
 use log::{debug, error};
 use rusqlite::types::ValueRef;
 use rusqlite::{Column, Row, Rows};
-use std::any::Any;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -71,10 +70,6 @@ impl Drop for SqliteConnection {
 
 #[async_trait::async_trait]
 impl Connection for SqliteConnection {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     async fn infer_schema(&self, source: &RemoteSource) -> DFResult<RemoteSchemaRef> {
         let conn = rusqlite::Connection::open(&self.path).map_err(|e| {
             DataFusionError::Plan(format!("Failed to open sqlite connection: {e:?}"))

--- a/remote-table/src/literalize.rs
+++ b/remote-table/src/literalize.rs
@@ -43,9 +43,7 @@ macro_rules! literalize_array {
     }};
 }
 
-pub trait Literalize: Debug + Send + Sync {
-    fn as_any(&self) -> &dyn Any;
-
+pub trait Literalize: Debug + Send + Sync + Any {
     fn literalize_null_array(
         &self,
         array: &NullArray,
@@ -610,11 +608,17 @@ pub fn literalize_array(
     }
 }
 
+impl dyn Literalize {
+    pub fn is<T: Literalize>(&self) -> bool {
+        (self as &dyn Any).is::<T>()
+    }
+
+    pub fn downcast_ref<T: Literalize>(&self) -> Option<&T> {
+        (self as &dyn Any).downcast_ref::<T>()
+    }
+}
+
 #[derive(Debug)]
 pub struct DefaultLiteralizer {}
 
-impl Literalize for DefaultLiteralizer {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-}
+impl Literalize for DefaultLiteralizer {}

--- a/remote-table/src/scan.rs
+++ b/remote-table/src/scan.rs
@@ -195,7 +195,7 @@ async fn build_and_transform_stream(
 
     let conn = pool.get().await?;
 
-    if transform.as_any().is::<DefaultTransform>() {
+    if transform.is::<DefaultTransform>() {
         conn.query(
             &conn_options,
             &source,

--- a/remote-table/src/table.rs
+++ b/remote-table/src/table.rs
@@ -237,7 +237,7 @@ impl RemoteTable {
             match (table_schema, remote_schema) {
                 (Some(table_schema), Some(remote_schema)) => (table_schema, Some(remote_schema)),
                 (Some(table_schema), None) => {
-                    let remote_schema = if transform.as_any().is::<DefaultTransform>()
+                    let remote_schema = if transform.is::<DefaultTransform>()
                         && matches!(source, RemoteSource::Query(_))
                     {
                         None
@@ -324,7 +324,7 @@ impl TableProvider for RemoteTable {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
-        let remote_schema = if self.transform.as_any().is::<DefaultTransform>() {
+        let remote_schema = if self.transform.is::<DefaultTransform>() {
             Arc::new(RemoteSchema::empty())
         } else {
             let Some(remote_schema) = &self.remote_schema else {
@@ -379,7 +379,7 @@ impl TableProvider for RemoteTable {
             ]);
         }
 
-        let remote_schema = if self.transform.as_any().is::<DefaultTransform>() {
+        let remote_schema = if self.transform.is::<DefaultTransform>() {
             Arc::new(RemoteSchema::empty())
         } else {
             let Some(remote_schema) = &self.remote_schema else {

--- a/remote-table/src/transform.rs
+++ b/remote-table/src/transform.rs
@@ -20,9 +20,7 @@ pub struct TransformArgs<'a> {
     pub remote_schema: &'a RemoteSchemaRef,
 }
 
-pub trait Transform: Debug + Send + Sync {
-    fn as_any(&self) -> &dyn Any;
-
+pub trait Transform: Debug + Send + Sync + Any {
     fn transform(&self, batch: RecordBatch, args: TransformArgs) -> DFResult<RecordBatch>;
 
     fn support_filter_pushdown(
@@ -34,14 +32,20 @@ pub trait Transform: Debug + Send + Sync {
     fn unparse_filter(&self, filter: &Expr, args: TransformArgs) -> DFResult<String>;
 }
 
+impl dyn Transform {
+    pub fn is<T: Transform>(&self) -> bool {
+        (self as &dyn Any).is::<T>()
+    }
+
+    pub fn downcast_ref<T: Transform>(&self) -> Option<&T> {
+        (self as &dyn Any).downcast_ref::<T>()
+    }
+}
+
 #[derive(Debug)]
 pub struct DefaultTransform {}
 
 impl Transform for DefaultTransform {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn transform(&self, batch: RecordBatch, _args: TransformArgs) -> DFResult<RecordBatch> {
         Ok(batch)
     }
@@ -168,7 +172,7 @@ pub fn transform_schema(
     remote_schema: Option<&RemoteSchemaRef>,
     db_type: RemoteDbType,
 ) -> DFResult<SchemaRef> {
-    if transform.as_any().is::<DefaultTransform>() {
+    if transform.is::<DefaultTransform>() {
         Ok(schema)
     } else {
         let Some(remote_schema) = remote_schema else {


### PR DESCRIPTION
## Background
This change removes `as_any` from the three public custom traits: `Connection`, `Transform`, and `Literalize`.

## Approach
- make `Connection`, `Transform`, and `Literalize` inherit from `Any`
- add `impl dyn Trait` helper methods for `is<T>()` and `downcast_ref<T>()`
- remove trait-specific `as_any()` requirements and corresponding implementations

## Scope
- only these 3 public traits and their implementations / call sites are changed
- Arrow / DataFusion external `as_any` usages are intentionally preserved
- this includes preserving external `ExecutionPlan::as_any`, `TableProvider::as_any`, and Arrow array / column downcasts

## Breaking change
This is a breaking change for external implementers of these public traits.
- external implementers must delete their custom `as_any()` implementations
- downstream type checks / downcasts should switch to the new `dyn Trait` helper methods: `is<T>()` and `downcast_ref<T>()`

## Verification
- `cargo fmt --all` ✅
- `cargo check --workspace --all-features` ✅
- `cargo clippy --workspace --all-features -- -D warnings` ✅
- `cargo test -p datafusion-remote-table` ✅
- `cargo test -p integration-tests --test common` ✅

## Additional note
`remote-table/src/connection/mysql.rs` contains one small clippy-compatibility adjustment with no behavior change.