### PR TITLE
feat: implement sql_binary_literal for Oracle, DM, and MDB

### DIFF
--- a/remote-table/src/connection/mod.rs
+++ b/remote-table/src/connection/mod.rs
@@ -335,7 +335,10 @@ impl RemoteDbType {
             RemoteDbType::Mysql | RemoteDbType::Sqlite => {
                 format!("X'{}'", hex::encode(value))
             }
-            RemoteDbType::Oracle | RemoteDbType::Dm | RemoteDbType::Mdb => todo!(),
+            RemoteDbType::Oracle | RemoteDbType::Dm => {
+                format!("HEXTORAW('{}')", hex::encode(value))
+            }
+            RemoteDbType::Mdb => format!("X'{}'", hex::encode(value)),
         }
     }
 


### PR DESCRIPTION
Remove the `todo!()` placeholder and implement binary literal formatting for remaining database types.

- Oracle/DM: `HEXTORAW('hex')`
- MDB: `X'hex'`