### PR TITLE
refactor: add count method to Connection trait

### DIFF
--- a/remote-table/src/connection/dm/mod.rs
+++ b/remote-table/src/connection/dm/mod.rs
@@ -228,9 +228,9 @@ impl Connection for DmConnection {
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
-        filters: &[String],
+        unparsed_filters: &[String],
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source, filters).await
+        crate::connection::connection_count(self, conn_options, source, unparsed_filters).await
     }
 }
 

--- a/remote-table/src/connection/dm/mod.rs
+++ b/remote-table/src/connection/dm/mod.rs
@@ -228,11 +228,8 @@ impl Connection for DmConnection {
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
-        unparsed_filters: &[String],
-        limit: Option<usize>,
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source, unparsed_filters, limit)
-            .await
+        crate::connection::connection_count(self, conn_options, source).await
     }
 }
 

--- a/remote-table/src/connection/dm/mod.rs
+++ b/remote-table/src/connection/dm/mod.rs
@@ -223,6 +223,17 @@ impl Connection for DmConnection {
             "Insert operation is not supported for dm".to_string(),
         ))
     }
+
+    async fn count(
+        &self,
+        conn_options: &ConnectionOptions,
+        source: &RemoteSource,
+        unparsed_filters: &[String],
+        limit: Option<usize>,
+    ) -> DFResult<Option<usize>> {
+        crate::connection::connection_count(self, conn_options, source, unparsed_filters, limit)
+            .await
+    }
 }
 
 fn build_remote_schema(mut cursor: CursorImpl<StatementImpl>) -> DFResult<RemoteSchema> {

--- a/remote-table/src/connection/dm/mod.rs
+++ b/remote-table/src/connection/dm/mod.rs
@@ -228,8 +228,9 @@ impl Connection for DmConnection {
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
+        filters: &[String],
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source).await
+        crate::connection::connection_count(self, conn_options, source, filters).await
     }
 }
 

--- a/remote-table/src/connection/mdb/mod.rs
+++ b/remote-table/src/connection/mdb/mod.rs
@@ -348,11 +348,8 @@ impl Connection for MdbConnection {
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
-        unparsed_filters: &[String],
-        limit: Option<usize>,
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source, unparsed_filters, limit)
-            .await
+        crate::connection::connection_count(self, conn_options, source).await
     }
 }
 

--- a/remote-table/src/connection/mdb/mod.rs
+++ b/remote-table/src/connection/mdb/mod.rs
@@ -348,8 +348,9 @@ impl Connection for MdbConnection {
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
+        filters: &[String],
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source).await
+        crate::connection::connection_count(self, conn_options, source, filters).await
     }
 }
 

--- a/remote-table/src/connection/mdb/mod.rs
+++ b/remote-table/src/connection/mdb/mod.rs
@@ -348,9 +348,9 @@ impl Connection for MdbConnection {
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
-        filters: &[String],
+        unparsed_filters: &[String],
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source, filters).await
+        crate::connection::connection_count(self, conn_options, source, unparsed_filters).await
     }
 }
 

--- a/remote-table/src/connection/mdb/mod.rs
+++ b/remote-table/src/connection/mdb/mod.rs
@@ -343,6 +343,17 @@ impl Connection for MdbConnection {
             "Insert operation is not supported for mdb".to_string(),
         ))
     }
+
+    async fn count(
+        &self,
+        conn_options: &ConnectionOptions,
+        source: &RemoteSource,
+        unparsed_filters: &[String],
+        limit: Option<usize>,
+    ) -> DFResult<Option<usize>> {
+        crate::connection::connection_count(self, conn_options, source, unparsed_filters, limit)
+            .await
+    }
 }
 
 /// List user tables in an MDB file using the ODBC `SQLTables` function.

--- a/remote-table/src/connection/mod.rs
+++ b/remote-table/src/connection/mod.rs
@@ -36,6 +36,7 @@ use datafusion_execution::SendableRecordBatchStream;
 use datafusion_physical_plan::common::collect;
 use datafusion_sql::unparser::Unparser;
 use datafusion_sql::unparser::dialect::{MySqlDialect, PostgreSqlDialect, SqliteDialect};
+use log::debug;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -76,6 +77,44 @@ pub trait Connection: Debug + Send + Sync + Any {
         remote_schema: RemoteSchemaRef,
         batch: RecordBatch,
     ) -> DFResult<usize>;
+
+    /// Fast row count using COUNT query pushdown.
+    /// Returns Some(count) if the backend supports COUNT optimization, None otherwise.
+    async fn count(
+        &self,
+        conn_options: &ConnectionOptions,
+        source: &RemoteSource,
+        unparsed_filters: &[String],
+        limit: Option<usize>,
+    ) -> DFResult<Option<usize>>;
+}
+
+/// Helper for implementing Connection::count().
+/// Generates COUNT SQL and executes it via the connection's query method.
+pub(crate) async fn connection_count(
+    conn: &dyn Connection,
+    conn_options: &ConnectionOptions,
+    source: &RemoteSource,
+    unparsed_filters: &[String],
+    limit: Option<usize>,
+) -> DFResult<Option<usize>> {
+    let db_type = conn_options.db_type();
+    let count1_query = if unparsed_filters.is_empty() && limit.is_none() {
+        db_type.try_count1_query(source)
+    } else {
+        let real_sql = db_type.rewrite_query(source, unparsed_filters, limit);
+        db_type.try_count1_query(&RemoteSource::Query(real_sql))
+    };
+
+    if let Some(count1_query) = count1_query {
+        debug!("[remote-table] fetching row count with query: {count1_query}");
+        let row_count = db_type
+            .fetch_count(conn, conn_options, &count1_query)
+            .await?;
+        Ok(Some(row_count))
+    } else {
+        Ok(None)
+    }
 }
 
 impl dyn Connection {
@@ -389,7 +428,7 @@ impl RemoteDbType {
 
     pub(crate) async fn fetch_count(
         &self,
-        conn: Arc<dyn Connection>,
+        conn: &dyn Connection,
         conn_options: &ConnectionOptions,
         count1_query: &str,
     ) -> DFResult<usize> {

--- a/remote-table/src/connection/mod.rs
+++ b/remote-table/src/connection/mod.rs
@@ -84,6 +84,7 @@ pub trait Connection: Debug + Send + Sync + Any {
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
+        filters: &[String],
     ) -> DFResult<Option<usize>>;
 }
 
@@ -93,9 +94,15 @@ pub(crate) async fn connection_count(
     conn: &dyn Connection,
     conn_options: &ConnectionOptions,
     source: &RemoteSource,
+    filters: &[String],
 ) -> DFResult<Option<usize>> {
     let db_type = conn_options.db_type();
-    if let Some(count1_query) = db_type.try_count1_query(source) {
+    let source = if filters.is_empty() {
+        source.clone()
+    } else {
+        RemoteSource::Query(db_type.rewrite_query(source, filters, None))
+    };
+    if let Some(count1_query) = db_type.try_count1_query(&source) {
         debug!("[remote-table] fetching row count with query: {count1_query}");
         let row_count = db_type
             .fetch_count(conn, conn_options, &count1_query)

--- a/remote-table/src/connection/mod.rs
+++ b/remote-table/src/connection/mod.rs
@@ -84,8 +84,6 @@ pub trait Connection: Debug + Send + Sync + Any {
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
-        unparsed_filters: &[String],
-        limit: Option<usize>,
     ) -> DFResult<Option<usize>>;
 }
 
@@ -95,18 +93,9 @@ pub(crate) async fn connection_count(
     conn: &dyn Connection,
     conn_options: &ConnectionOptions,
     source: &RemoteSource,
-    unparsed_filters: &[String],
-    limit: Option<usize>,
 ) -> DFResult<Option<usize>> {
     let db_type = conn_options.db_type();
-    let count1_query = if unparsed_filters.is_empty() && limit.is_none() {
-        db_type.try_count1_query(source)
-    } else {
-        let real_sql = db_type.rewrite_query(source, unparsed_filters, limit);
-        db_type.try_count1_query(&RemoteSource::Query(real_sql))
-    };
-
-    if let Some(count1_query) = count1_query {
+    if let Some(count1_query) = db_type.try_count1_query(source) {
         debug!("[remote-table] fetching row count with query: {count1_query}");
         let row_count = db_type
             .fetch_count(conn, conn_options, &count1_query)

--- a/remote-table/src/connection/mod.rs
+++ b/remote-table/src/connection/mod.rs
@@ -84,7 +84,7 @@ pub trait Connection: Debug + Send + Sync + Any {
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
-        filters: &[String],
+        unparsed_filters: &[String],
     ) -> DFResult<Option<usize>>;
 }
 
@@ -94,13 +94,13 @@ pub(crate) async fn connection_count(
     conn: &dyn Connection,
     conn_options: &ConnectionOptions,
     source: &RemoteSource,
-    filters: &[String],
+    unparsed_filters: &[String],
 ) -> DFResult<Option<usize>> {
     let db_type = conn_options.db_type();
-    let source = if filters.is_empty() {
+    let source = if unparsed_filters.is_empty() {
         source.clone()
     } else {
-        RemoteSource::Query(db_type.rewrite_query(source, filters, None))
+        RemoteSource::Query(db_type.rewrite_query(source, unparsed_filters, None))
     };
     if let Some(count1_query) = db_type.try_count1_query(&source) {
         debug!("[remote-table] fetching row count with query: {count1_query}");

--- a/remote-table/src/connection/mysql.rs
+++ b/remote-table/src/connection/mysql.rs
@@ -168,9 +168,9 @@ impl Connection for MysqlConnection {
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
-        filters: &[String],
+        unparsed_filters: &[String],
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source, filters).await
+        crate::connection::connection_count(self, conn_options, source, unparsed_filters).await
     }
 }
 

--- a/remote-table/src/connection/mysql.rs
+++ b/remote-table/src/connection/mysql.rs
@@ -168,8 +168,9 @@ impl Connection for MysqlConnection {
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
+        filters: &[String],
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source).await
+        crate::connection::connection_count(self, conn_options, source, filters).await
     }
 }
 

--- a/remote-table/src/connection/mysql.rs
+++ b/remote-table/src/connection/mysql.rs
@@ -168,11 +168,8 @@ impl Connection for MysqlConnection {
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
-        unparsed_filters: &[String],
-        limit: Option<usize>,
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source, unparsed_filters, limit)
-            .await
+        crate::connection::connection_count(self, conn_options, source).await
     }
 }
 

--- a/remote-table/src/connection/mysql.rs
+++ b/remote-table/src/connection/mysql.rs
@@ -163,6 +163,17 @@ impl Connection for MysqlConnection {
             "Insert operation is not supported for mysql".to_string(),
         ))
     }
+
+    async fn count(
+        &self,
+        conn_options: &ConnectionOptions,
+        source: &RemoteSource,
+        unparsed_filters: &[String],
+        limit: Option<usize>,
+    ) -> DFResult<Option<usize>> {
+        crate::connection::connection_count(self, conn_options, source, unparsed_filters, limit)
+            .await
+    }
 }
 
 fn mysql_type_to_remote_type(mysql_col: &Column) -> DFResult<MysqlType> {

--- a/remote-table/src/connection/oracle.rs
+++ b/remote-table/src/connection/oracle.rs
@@ -141,8 +141,9 @@ impl Connection for OracleConnection {
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
+        filters: &[String],
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source).await
+        crate::connection::connection_count(self, conn_options, source, filters).await
     }
 }
 

--- a/remote-table/src/connection/oracle.rs
+++ b/remote-table/src/connection/oracle.rs
@@ -141,11 +141,8 @@ impl Connection for OracleConnection {
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
-        unparsed_filters: &[String],
-        limit: Option<usize>,
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source, unparsed_filters, limit)
-            .await
+        crate::connection::connection_count(self, conn_options, source).await
     }
 }
 

--- a/remote-table/src/connection/oracle.rs
+++ b/remote-table/src/connection/oracle.rs
@@ -136,6 +136,17 @@ impl Connection for OracleConnection {
             "Insert operation is not supported for oracle".to_string(),
         ))
     }
+
+    async fn count(
+        &self,
+        conn_options: &ConnectionOptions,
+        source: &RemoteSource,
+        unparsed_filters: &[String],
+        limit: Option<usize>,
+    ) -> DFResult<Option<usize>> {
+        crate::connection::connection_count(self, conn_options, source, unparsed_filters, limit)
+            .await
+    }
 }
 
 fn oracle_type_to_remote_type(oracle_type: &ColumnType) -> DFResult<OracleType> {

--- a/remote-table/src/connection/oracle.rs
+++ b/remote-table/src/connection/oracle.rs
@@ -141,9 +141,9 @@ impl Connection for OracleConnection {
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
-        filters: &[String],
+        unparsed_filters: &[String],
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source, filters).await
+        crate::connection::connection_count(self, conn_options, source, unparsed_filters).await
     }
 }
 

--- a/remote-table/src/connection/postgres.rs
+++ b/remote-table/src/connection/postgres.rs
@@ -268,11 +268,8 @@ order by ordinal_position",
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
-        unparsed_filters: &[String],
-        limit: Option<usize>,
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source, unparsed_filters, limit)
-            .await
+        crate::connection::connection_count(self, conn_options, source).await
     }
 }
 

--- a/remote-table/src/connection/postgres.rs
+++ b/remote-table/src/connection/postgres.rs
@@ -263,6 +263,17 @@ order by ordinal_position",
 
         Ok(count as usize)
     }
+
+    async fn count(
+        &self,
+        conn_options: &ConnectionOptions,
+        source: &RemoteSource,
+        unparsed_filters: &[String],
+        limit: Option<usize>,
+    ) -> DFResult<Option<usize>> {
+        crate::connection::connection_count(self, conn_options, source, unparsed_filters, limit)
+            .await
+    }
 }
 
 async fn build_remote_schema_for_query(

--- a/remote-table/src/connection/postgres.rs
+++ b/remote-table/src/connection/postgres.rs
@@ -268,9 +268,9 @@ order by ordinal_position",
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
-        filters: &[String],
+        unparsed_filters: &[String],
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source, filters).await
+        crate::connection::connection_count(self, conn_options, source, unparsed_filters).await
     }
 }
 

--- a/remote-table/src/connection/postgres.rs
+++ b/remote-table/src/connection/postgres.rs
@@ -268,8 +268,9 @@ order by ordinal_position",
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
+        filters: &[String],
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source).await
+        crate::connection::connection_count(self, conn_options, source, filters).await
     }
 }
 

--- a/remote-table/src/connection/sqlite.rs
+++ b/remote-table/src/connection/sqlite.rs
@@ -199,8 +199,9 @@ impl Connection for SqliteConnection {
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
+        filters: &[String],
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source).await
+        crate::connection::connection_count(self, conn_options, source, filters).await
     }
 }
 

--- a/remote-table/src/connection/sqlite.rs
+++ b/remote-table/src/connection/sqlite.rs
@@ -194,6 +194,17 @@ impl Connection for SqliteConnection {
 
         Ok(count)
     }
+
+    async fn count(
+        &self,
+        conn_options: &ConnectionOptions,
+        source: &RemoteSource,
+        unparsed_filters: &[String],
+        limit: Option<usize>,
+    ) -> DFResult<Option<usize>> {
+        crate::connection::connection_count(self, conn_options, source, unparsed_filters, limit)
+            .await
+    }
 }
 
 #[derive(Debug)]

--- a/remote-table/src/connection/sqlite.rs
+++ b/remote-table/src/connection/sqlite.rs
@@ -199,9 +199,9 @@ impl Connection for SqliteConnection {
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
-        filters: &[String],
+        unparsed_filters: &[String],
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source, filters).await
+        crate::connection::connection_count(self, conn_options, source, unparsed_filters).await
     }
 }
 

--- a/remote-table/src/connection/sqlite.rs
+++ b/remote-table/src/connection/sqlite.rs
@@ -199,11 +199,8 @@ impl Connection for SqliteConnection {
         &self,
         conn_options: &ConnectionOptions,
         source: &RemoteSource,
-        unparsed_filters: &[String],
-        limit: Option<usize>,
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source, unparsed_filters, limit)
-            .await
+        crate::connection::connection_count(self, conn_options, source).await
     }
 }
 

--- a/remote-table/src/table.rs
+++ b/remote-table/src/table.rs
@@ -487,22 +487,7 @@ pub(crate) async fn fetch_row_count(
     unparsed_filters: &[String],
     limit: Option<usize>,
 ) -> DFResult<Option<usize>> {
-    let db_type = conn_options.db_type();
-    let count1_query = if unparsed_filters.is_empty() && limit.is_none() {
-        db_type.try_count1_query(source)
-    } else {
-        let real_sql = db_type.rewrite_query(source, unparsed_filters, limit);
-        db_type.try_count1_query(&RemoteSource::Query(real_sql))
-    };
-
-    if let Some(count1_query) = count1_query {
-        debug!("[remote-table] fetching row count with query: {count1_query}");
-        let conn = pool.get().await?;
-        let row_count = db_type
-            .fetch_count(conn, conn_options, &count1_query)
-            .await?;
-        Ok(Some(row_count))
-    } else {
-        Ok(None)
-    }
+    let conn = pool.get().await?;
+    conn.count(conn_options, source, unparsed_filters, limit)
+        .await
 }

--- a/remote-table/src/table.rs
+++ b/remote-table/src/table.rs
@@ -276,7 +276,7 @@ impl RemoteTable {
         )?;
 
         let row_count = if enable_table_statistics {
-            fetch_row_count(&pool, &conn_options, &source, &[], None).await?
+            fetch_row_count(&pool, &conn_options, &source).await?
         } else {
             None
         };
@@ -344,14 +344,16 @@ impl TableProvider for RemoteTable {
             unparsed_filters.push(self.transform.unparse_filter(filter, args)?);
         }
 
-        let row_count = fetch_row_count(
-            &self.pool,
-            &self.conn_options,
-            &self.source,
-            &unparsed_filters,
-            None,
-        )
-        .await?;
+        let source = if unparsed_filters.is_empty() {
+            self.source.clone()
+        } else {
+            RemoteSource::Query(self.conn_options.db_type().rewrite_query(
+                &self.source,
+                &unparsed_filters,
+                None,
+            ))
+        };
+        let row_count = fetch_row_count(&self.pool, &self.conn_options, &source).await?;
 
         Ok(Arc::new(RemoteTableScanExec::try_new(
             self.conn_options.clone(),
@@ -484,15 +486,7 @@ pub(crate) async fn fetch_row_count(
     pool: &LazyPool,
     conn_options: &ConnectionOptions,
     source: &RemoteSource,
-    unparsed_filters: &[String],
-    limit: Option<usize>,
 ) -> DFResult<Option<usize>> {
-    let db_type = conn_options.db_type();
-    let source = if unparsed_filters.is_empty() && limit.is_none() {
-        source.clone()
-    } else {
-        RemoteSource::Query(db_type.rewrite_query(source, unparsed_filters, limit))
-    };
     let conn = pool.get().await?;
-    conn.count(conn_options, &source).await
+    conn.count(conn_options, source).await
 }

--- a/remote-table/src/table.rs
+++ b/remote-table/src/table.rs
@@ -483,8 +483,8 @@ pub(crate) async fn fetch_row_count(
     pool: &LazyPool,
     conn_options: &ConnectionOptions,
     source: &RemoteSource,
-    filters: &[String],
+    unparsed_filters: &[String],
 ) -> DFResult<Option<usize>> {
     let conn = pool.get().await?;
-    conn.count(conn_options, source, filters).await
+    conn.count(conn_options, source, unparsed_filters).await
 }

--- a/remote-table/src/table.rs
+++ b/remote-table/src/table.rs
@@ -487,7 +487,12 @@ pub(crate) async fn fetch_row_count(
     unparsed_filters: &[String],
     limit: Option<usize>,
 ) -> DFResult<Option<usize>> {
+    let db_type = conn_options.db_type();
+    let source = if unparsed_filters.is_empty() && limit.is_none() {
+        source.clone()
+    } else {
+        RemoteSource::Query(db_type.rewrite_query(source, unparsed_filters, limit))
+    };
     let conn = pool.get().await?;
-    conn.count(conn_options, source, unparsed_filters, limit)
-        .await
+    conn.count(conn_options, &source).await
 }

--- a/remote-table/src/table.rs
+++ b/remote-table/src/table.rs
@@ -276,7 +276,7 @@ impl RemoteTable {
         )?;
 
         let row_count = if enable_table_statistics {
-            fetch_row_count(&pool, &conn_options, &source).await?
+            fetch_row_count(&pool, &conn_options, &source, &[]).await?
         } else {
             None
         };
@@ -344,16 +344,13 @@ impl TableProvider for RemoteTable {
             unparsed_filters.push(self.transform.unparse_filter(filter, args)?);
         }
 
-        let source = if unparsed_filters.is_empty() {
-            self.source.clone()
-        } else {
-            RemoteSource::Query(self.conn_options.db_type().rewrite_query(
-                &self.source,
-                &unparsed_filters,
-                None,
-            ))
-        };
-        let row_count = fetch_row_count(&self.pool, &self.conn_options, &source).await?;
+        let row_count = fetch_row_count(
+            &self.pool,
+            &self.conn_options,
+            &self.source,
+            &unparsed_filters,
+        )
+        .await?;
 
         Ok(Arc::new(RemoteTableScanExec::try_new(
             self.conn_options.clone(),
@@ -486,7 +483,8 @@ pub(crate) async fn fetch_row_count(
     pool: &LazyPool,
     conn_options: &ConnectionOptions,
     source: &RemoteSource,
+    filters: &[String],
 ) -> DFResult<Option<usize>> {
     let conn = pool.get().await?;
-    conn.count(conn_options, source).await
+    conn.count(conn_options, source, filters).await
 }


### PR DESCRIPTION
Add `count()` method to the `Connection` trait for fast row counting via COUNT query pushdown.

### Changes
- Add `count()` method to `Connection` trait
- Add `connection_count()` helper function for shared implementation
- Implement `count()` for all 6 backends (postgres, mysql, oracle, sqlite, dm, mdb)
- Update `table.rs` `fetch_row_count()` to use `conn.count()`
- Change `fetch_count()` to accept `&dyn Connection` instead of `Arc<dyn Connection>`

### Verification
- ✅ cargo clippy --all-features -- -D warnings
- ✅ cargo fmt --check
- ✅ cargo test --test mdb (11/11)