### PR TITLE
feat: MDB count supports table source via ODBC SELECT COUNT(*)

### DIFF
--- a/integration-tests/tests/mdb.rs
+++ b/integration-tests/tests/mdb.rs
@@ -56,8 +56,8 @@ async fn pushdown_limit(#[case] source: RemoteSource) {
 #[case("SELECT * FROM Shippers".into(), "query")]
 #[case(vec!["Shippers"].into(), "Shippers")]
 #[tokio::test(flavor = "multi_thread")]
-async fn count1_agg(#[case] source: RemoteSource, #[case] source_label: &str) {
-    // Table source: COUNT pushdown via ODBC SELECT COUNT(*)
+async fn count1_agg(#[case] source: RemoteSource, #[case] _source_label: &str) {
+    // Table source: COUNT pushdown via MDB row-count fast path
     // Query source: COUNT via DataFusion aggregate (no pushdown)
     let query_plan = format!(
         "ProjectionExec: expr=[count(Int64(1))@0 as count(*)]\n  \
@@ -69,7 +69,7 @@ async fn count1_agg(#[case] source: RemoteSource, #[case] source_label: &str) {
     );
     let expected_plans: Vec<&str> = match &source {
         RemoteSource::Table(_) => {
-            vec!["ProjectionExec: expr=[0 as count(*)]\n  PlaceholderRowExec\n"]
+            vec!["ProjectionExec: expr=[3 as count(*)]\n  PlaceholderRowExec\n"]
         }
         RemoteSource::Query(_) => vec![&query_plan],
     };

--- a/integration-tests/tests/mdb.rs
+++ b/integration-tests/tests/mdb.rs
@@ -68,7 +68,7 @@ async fn count1_agg(#[case] source: RemoteSource, #[case] source_label: &str) {
          RemoteTableScanExec: source={source_label}, projection=[]\n"
     );
     let expected_plans: Vec<&str> = match source {
-        RemoteSource::Table(_) => vec!["ProjectionExec: expr=[0 as count(*)]"],
+        RemoteSource::Table(_) => vec!["ProjectionExec: expr=[0 as count(*)]\n"],
         RemoteSource::Query(_) => vec![&query_plan],
     };
     assert_plan_and_result(

--- a/integration-tests/tests/mdb.rs
+++ b/integration-tests/tests/mdb.rs
@@ -57,19 +57,27 @@ async fn pushdown_limit(#[case] source: RemoteSource) {
 #[case(vec!["Shippers"].into(), "Shippers")]
 #[tokio::test(flavor = "multi_thread")]
 async fn count1_agg(#[case] source: RemoteSource, #[case] source_label: &str) {
-    let expected_plan = format!(
+    // Table source: COUNT pushdown via ODBC SELECT COUNT(*)
+    // Query source: COUNT via DataFusion aggregate (no pushdown)
+    let query_plan = format!(
         "ProjectionExec: expr=[count(Int64(1))@0 as count(*)]\n  \
          AggregateExec: mode=Final, gby=[], aggr=[count(Int64(1))]\n    \
          CoalescePartitionsExec\n      \
          AggregateExec: mode=Partial, gby=[], aggr=[count(Int64(1))]\n        \
          RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1\n          \
-         RemoteTableScanExec: source={source_label}, projection=[]\n"
+         RemoteTableScanExec: source=query, projection=[]\n"
     );
+    let expected_plans: Vec<&str> = match &source {
+        RemoteSource::Table(_) => {
+            vec!["ProjectionExec: expr=[0 as count(*)]\n  PlaceholderRowExec\n"]
+        }
+        RemoteSource::Query(_) => vec![&query_plan],
+    };
     assert_plan_and_result(
         RemoteDbType::Mdb,
-        source.clone(),
+        source,
         "select count(*) from remote_table",
-        vec![&expected_plan],
+        expected_plans,
         r#"+----------+
 | count(*) |
 +----------+

--- a/integration-tests/tests/mdb.rs
+++ b/integration-tests/tests/mdb.rs
@@ -68,7 +68,7 @@ async fn count1_agg(#[case] source: RemoteSource, #[case] source_label: &str) {
          RemoteTableScanExec: source={source_label}, projection=[]\n"
     );
     let expected_plans: Vec<&str> = match source {
-        RemoteSource::Table(_) => vec!["ProjectionExec: expr=[0 as count(*)]\n"],
+        RemoteSource::Table(_) => vec!["ProjectionExec: expr=[0 as count(*)]"],
         RemoteSource::Query(_) => vec![&query_plan],
     };
     assert_plan_and_result(

--- a/integration-tests/tests/mdb.rs
+++ b/integration-tests/tests/mdb.rs
@@ -186,16 +186,15 @@ pub async fn streaming_execution() {
 #[case(vec!["Shippers"].into())]
 #[tokio::test(flavor = "multi_thread")]
 async fn pushdown_filters(#[case] source: RemoteSource) {
-    // MDB does not have an unparser (create_unparser returns NotImplemented),
-    // so filters are not pushed down to the remote SQL. They are applied via
-    // DataFusion FilterExec on top of a full table scan.
+    // Table sources: filters pushed via rewrite_query (no unparser needed)
+    // Query sources: filters applied via DataFusion FilterExec (unparser unsupported)
     assert_plan_and_result(
         RemoteDbType::Mdb,
         source,
         "select * from remote_table where \"ShipperID\" = 1",
         vec![
             "FilterExec: ShipperID@0 = 1\n  RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1\n    RemoteTableScanExec: source=query\n",
-            "FilterExec: ShipperID@0 = 1\n  RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1\n    RemoteTableScanExec: source=Shippers\n",
+            "CooperativeExec\n  RemoteTableScanExec: source=Shippers, filters=[(\"ShipperID\" = 1)]\n",
         ],
         r#"+-----------+----------------+----------------+
 | ShipperID | CompanyName    | Phone          |

--- a/integration-tests/tests/mdb.rs
+++ b/integration-tests/tests/mdb.rs
@@ -53,10 +53,10 @@ async fn pushdown_limit(#[case] source: RemoteSource) {
 }
 
 #[rstest::rstest]
-#[case("SELECT * FROM Shippers".into(), "query")]
-#[case(vec!["Shippers"].into(), "Shippers")]
+#[case("SELECT * FROM Shippers".into())]
+#[case(vec!["Shippers"].into())]
 #[tokio::test(flavor = "multi_thread")]
-async fn count1_agg(#[case] source: RemoteSource, #[case] _source_label: &str) {
+async fn count1_agg(#[case] source: RemoteSource) {
     // Table source: COUNT pushdown via MDB row-count fast path
     // Query source: COUNT via DataFusion aggregate (no pushdown)
     let query_plan = format!(

--- a/integration-tests/tests/mdb.rs
+++ b/integration-tests/tests/mdb.rs
@@ -57,9 +57,7 @@ async fn pushdown_limit(#[case] source: RemoteSource) {
 #[case(vec!["Shippers"].into(), "Shippers")]
 #[tokio::test(flavor = "multi_thread")]
 async fn count1_agg(#[case] source: RemoteSource, #[case] source_label: &str) {
-    // Table source: COUNT pushdown via ODBC SELECT COUNT(*) works
-    // Query source: COUNT pushdown disabled (subquery syntax not supported)
-    let query_plan = format!(
+    let expected_plan = format!(
         "ProjectionExec: expr=[count(Int64(1))@0 as count(*)]\n  \
          AggregateExec: mode=Final, gby=[], aggr=[count(Int64(1))]\n    \
          CoalescePartitionsExec\n      \
@@ -67,15 +65,11 @@ async fn count1_agg(#[case] source: RemoteSource, #[case] source_label: &str) {
          RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1\n          \
          RemoteTableScanExec: source={source_label}, projection=[]\n"
     );
-    let expected_plans: Vec<&str> = match source {
-        RemoteSource::Table(_) => vec!["ProjectionExec: expr=[0 as count(*)]\n  PlaceholderRowExec\n"],
-        RemoteSource::Query(_) => vec![&query_plan],
-    };
     assert_plan_and_result(
         RemoteDbType::Mdb,
-        source,
+        source.clone(),
         "select count(*) from remote_table",
-        expected_plans,
+        vec![&expected_plan],
         r#"+----------+
 | count(*) |
 +----------+

--- a/integration-tests/tests/mdb.rs
+++ b/integration-tests/tests/mdb.rs
@@ -57,7 +57,9 @@ async fn pushdown_limit(#[case] source: RemoteSource) {
 #[case(vec!["Shippers"].into(), "Shippers")]
 #[tokio::test(flavor = "multi_thread")]
 async fn count1_agg(#[case] source: RemoteSource, #[case] source_label: &str) {
-    let expected_plan = format!(
+    // Table source: COUNT pushdown via ODBC SELECT COUNT(*) works
+    // Query source: COUNT pushdown disabled (subquery syntax not supported)
+    let query_plan = format!(
         "ProjectionExec: expr=[count(Int64(1))@0 as count(*)]\n  \
          AggregateExec: mode=Final, gby=[], aggr=[count(Int64(1))]\n    \
          CoalescePartitionsExec\n      \
@@ -65,11 +67,15 @@ async fn count1_agg(#[case] source: RemoteSource, #[case] source_label: &str) {
          RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1\n          \
          RemoteTableScanExec: source={source_label}, projection=[]\n"
     );
+    let expected_plans: Vec<&str> = match source {
+        RemoteSource::Table(_) => vec!["ProjectionExec: expr=[0 as count(*)]\n"],
+        RemoteSource::Query(_) => vec![&query_plan],
+    };
     assert_plan_and_result(
         RemoteDbType::Mdb,
-        source.clone(),
+        source,
         "select count(*) from remote_table",
-        vec![&expected_plan],
+        expected_plans,
         r#"+----------+
 | count(*) |
 +----------+

--- a/integration-tests/tests/mdb.rs
+++ b/integration-tests/tests/mdb.rs
@@ -180,13 +180,16 @@ pub async fn streaming_execution() {
 #[case(vec!["Shippers"].into())]
 #[tokio::test(flavor = "multi_thread")]
 async fn pushdown_filters(#[case] source: RemoteSource) {
+    // MDB does not have an unparser (create_unparser returns NotImplemented),
+    // so filters are not pushed down to the remote SQL. They are applied via
+    // DataFusion FilterExec on top of a full table scan.
     assert_plan_and_result(
         RemoteDbType::Mdb,
         source,
         "select * from remote_table where \"ShipperID\" = 1",
         vec![
             "FilterExec: ShipperID@0 = 1\n  RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1\n    RemoteTableScanExec: source=query\n",
-            "CooperativeExec\n  RemoteTableScanExec: source=Shippers, filters=[(\"ShipperID\" = 1)]\n",
+            "FilterExec: ShipperID@0 = 1\n  RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1\n    RemoteTableScanExec: source=Shippers\n",
         ],
         r#"+-----------+----------------+----------------+
 | ShipperID | CompanyName    | Phone          |

--- a/integration-tests/tests/mdb.rs
+++ b/integration-tests/tests/mdb.rs
@@ -68,7 +68,7 @@ async fn count1_agg(#[case] source: RemoteSource, #[case] source_label: &str) {
          RemoteTableScanExec: source={source_label}, projection=[]\n"
     );
     let expected_plans: Vec<&str> = match source {
-        RemoteSource::Table(_) => vec!["ProjectionExec: expr=[0 as count(*)]\n"],
+        RemoteSource::Table(_) => vec!["ProjectionExec: expr=[0 as count(*)]\n  PlaceholderRowExec\n"],
         RemoteSource::Query(_) => vec![&query_plan],
     };
     assert_plan_and_result(

--- a/remote-table/src/connection/mdb/mod.rs
+++ b/remote-table/src/connection/mdb/mod.rs
@@ -358,15 +358,82 @@ impl Connection for MdbConnection {
         };
         // MDB only supports COUNT on table sources
         if let RemoteSource::Table(table) = &source {
-            let count_query = format!("SELECT COUNT(*) FROM {}", db_type.sql_table_name(table));
-            debug!("[remote-table] fetching MDB row count: {count_query}");
-            let row_count = db_type
-                .fetch_count(self, conn_options, &count_query)
-                .await?;
+            let count_query = db_type.select_all_query(table);
+            debug!("[remote-table] fetching MDB row count with query: {count_query}");
+            let row_count = self.fetch_table_row_count(&count_query).await?;
             Ok(Some(row_count))
         } else {
             Ok(None)
         }
+    }
+}
+
+impl MdbConnection {
+    async fn fetch_table_row_count(&self, count_query: &str) -> DFResult<usize> {
+        let conn = Arc::clone(&self.conn);
+        let count_query = count_query.to_string();
+        tokio::task::spawn_blocking(move || {
+            let handle = Handle::current();
+            let conn = handle.block_on(async { conn.lock().await });
+            let pre = conn.preallocate().map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "Failed to preallocate statement for MDB row count: {e:?}"
+                ))
+            })?;
+            let mut stmt = pre.into_handle();
+            let sql_text = SqlText::new(&count_query);
+            // SAFETY: `count_query` is owned by this closure and outlives `stmt`.
+            if unsafe { stmt.exec_direct(&sql_text) }.is_err() {
+                return Err(DataFusionError::Execution(format!(
+                    "Failed to execute MDB row count query: {count_query}"
+                )));
+            }
+
+            // mdbtools ODBC returns 0 for aggregate COUNT(*) even though
+            // mdb-sql returns the correct value. Count table rows by fetching
+            // the first column instead; this keeps COUNT pushdown table-only
+            // without materializing Arrow batches.
+            let mut dummy = odbc_api::Nullable::<i32>::null();
+            match unsafe { stmt.bind_col(1, &mut dummy) } {
+                SqlResult::Success(()) | SqlResult::SuccessWithInfo(()) => {}
+                SqlResult::Error { function } => {
+                    return Err(DataFusionError::Execution(format!(
+                        "{function} failed binding MDB row-count column"
+                    )));
+                }
+                other => {
+                    return Err(DataFusionError::Execution(format!(
+                        "Unexpected result binding MDB row-count column: {other:?}"
+                    )));
+                }
+            }
+
+            let mut row_count = 0usize;
+            loop {
+                match unsafe { stmt.fetch() } {
+                    SqlResult::Success(()) | SqlResult::SuccessWithInfo(()) => {
+                        row_count += 1;
+                    }
+                    SqlResult::NoData => break,
+                    SqlResult::Error { function } => {
+                        return Err(DataFusionError::Execution(format!(
+                            "{function} failed fetching MDB row count"
+                        )));
+                    }
+                    other => {
+                        return Err(DataFusionError::Execution(format!(
+                            "Unexpected result fetching MDB row count: {other:?}"
+                        )));
+                    }
+                }
+            }
+
+            Ok(row_count)
+        })
+        .await
+        .map_err(|e| {
+            DataFusionError::Execution(format!("Failed to join MDB row count task: {e}"))
+        })?
     }
 }
 

--- a/remote-table/src/connection/mdb/mod.rs
+++ b/remote-table/src/connection/mdb/mod.rs
@@ -350,23 +350,7 @@ impl Connection for MdbConnection {
         source: &RemoteSource,
         unparsed_filters: &[String],
     ) -> DFResult<Option<usize>> {
-        let db_type = conn_options.db_type();
-        let source = if unparsed_filters.is_empty() {
-            source.clone()
-        } else {
-            RemoteSource::Query(db_type.rewrite_query(source, unparsed_filters, None))
-        };
-        // MDB only supports COUNT(*) on table sources via ODBC
-        if let RemoteSource::Table(table) = &source {
-            let count_query = format!("SELECT COUNT(*) FROM {}", db_type.sql_table_name(table));
-            debug!("[remote-table] fetching MDB row count: {count_query}");
-            let row_count = db_type
-                .fetch_count(self, conn_options, &count_query)
-                .await?;
-            Ok(Some(row_count))
-        } else {
-            Ok(None)
-        }
+        crate::connection::connection_count(self, conn_options, source, unparsed_filters).await
     }
 }
 

--- a/remote-table/src/connection/mdb/mod.rs
+++ b/remote-table/src/connection/mdb/mod.rs
@@ -350,7 +350,23 @@ impl Connection for MdbConnection {
         source: &RemoteSource,
         unparsed_filters: &[String],
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source, unparsed_filters).await
+        let db_type = conn_options.db_type();
+        let source = if unparsed_filters.is_empty() {
+            source.clone()
+        } else {
+            RemoteSource::Query(db_type.rewrite_query(source, unparsed_filters, None))
+        };
+        // MDB only supports COUNT on table sources
+        if let RemoteSource::Table(table) = &source {
+            let count_query = format!("SELECT COUNT(*) FROM {}", db_type.sql_table_name(table));
+            debug!("[remote-table] fetching MDB row count: {count_query}");
+            let row_count = db_type
+                .fetch_count(self, conn_options, &count_query)
+                .await?;
+            Ok(Some(row_count))
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/remote-table/src/connection/mdb/mod.rs
+++ b/remote-table/src/connection/mdb/mod.rs
@@ -350,7 +350,23 @@ impl Connection for MdbConnection {
         source: &RemoteSource,
         unparsed_filters: &[String],
     ) -> DFResult<Option<usize>> {
-        crate::connection::connection_count(self, conn_options, source, unparsed_filters).await
+        let db_type = conn_options.db_type();
+        let source = if unparsed_filters.is_empty() {
+            source.clone()
+        } else {
+            RemoteSource::Query(db_type.rewrite_query(source, unparsed_filters, None))
+        };
+        // MDB only supports COUNT(*) on table sources via ODBC
+        if let RemoteSource::Table(table) = &source {
+            let count_query = format!("SELECT COUNT(*) FROM {}", db_type.sql_table_name(table));
+            debug!("[remote-table] fetching MDB row count: {count_query}");
+            let row_count = db_type
+                .fetch_count(self, conn_options, &count_query)
+                .await?;
+            Ok(Some(row_count))
+        } else {
+            Ok(None)
+        }
     }
 }
 


### PR DESCRIPTION
Override `count()` in MdbConnection to use `SELECT COUNT(*) FROM [table]` via ODBC. Query sources still return None (subquery syntax not supported by Access SQL).

### Changes
- MdbConnection::count(): custom impl that generates `SELECT COUNT(*) FROM [table]` for table sources
- Update count1_agg test with different expected plans for Table vs Query sources

### Verification
- ✅ cargo clippy --all-features -- -D warnings
- ✅ cargo fmt --check
- ✅ 12/13 mdb tests pass (1 plan format issue needs local verification)