### PR TITLE
feat(mdb): integrate list_tables into MdbConnection via magic table

### DIFF
--- a/integration-tests/tests/mdb.rs
+++ b/integration-tests/tests/mdb.rs
@@ -3,7 +3,7 @@ use datafusion::physical_plan::collect;
 use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion_remote_table::{
-    ConnectionOptions, MdbConnectionOptions, RemoteCommand, RemoteDbType, RemoteSource, RemoteTable,
+    ConnectionOptions, MdbConnectionOptions, RemoteDbType, RemoteSource, RemoteTable, SourceCommand,
 };
 use integration_tests::setup_mdb;
 use integration_tests::utils::{assert_plan_and_result, assert_result, build_conn_options};
@@ -211,7 +211,7 @@ async fn pushdown_filters(#[case] source: RemoteSource) {
 #[tokio::test(flavor = "multi_thread")]
 async fn list_tables() {
     let options = build_conn_options(RemoteDbType::Mdb);
-    let table = RemoteTable::try_new(options, RemoteSource::Command(RemoteCommand::ListMdbTables))
+    let table = RemoteTable::try_new(options, RemoteSource::Command(SourceCommand::ListMdbTables))
         .await
         .unwrap();
 

--- a/integration-tests/tests/mdb.rs
+++ b/integration-tests/tests/mdb.rs
@@ -3,7 +3,8 @@ use datafusion::physical_plan::collect;
 use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion_remote_table::{
-    ConnectionOptions, MdbConnectionOptions, RemoteDbType, RemoteSource, RemoteTable,
+    ConnectionOptions, MDB_LIST_TABLES_MAGIC, MdbConnectionOptions, RemoteDbType, RemoteSource,
+    RemoteTable,
 };
 use integration_tests::setup_mdb;
 use integration_tests::utils::{assert_plan_and_result, assert_result, build_conn_options};
@@ -205,4 +206,33 @@ async fn pushdown_filters(#[case] source: RemoteSource) {
 +-----------+----------------+----------------+"#,
     )
     .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_tables() {
+    let options = build_conn_options(RemoteDbType::Mdb);
+    let table = RemoteTable::try_new(options, RemoteSource::from(vec![MDB_LIST_TABLES_MAGIC]))
+        .await
+        .unwrap();
+
+    let ctx = SessionContext::new();
+    ctx.register_table("remote_table", Arc::new(table)).unwrap();
+
+    // Verify the magic table returns table_name and table_type columns
+    // containing expected Northwind tables
+    let df = ctx
+        .sql("select * from remote_table order by table_name")
+        .await
+        .unwrap();
+    let result = collect(df.create_physical_plan().await.unwrap(), ctx.task_ctx())
+        .await
+        .unwrap();
+    let formatted = pretty_format_batches(&result).unwrap().to_string();
+
+    // Northwind sample database should contain these well-known tables
+    assert!(formatted.contains("Shippers"));
+    assert!(formatted.contains("Products"));
+    assert!(formatted.contains("Table"));
+
+    println!("Tables in nwind.mdb:\n{formatted}");
 }

--- a/integration-tests/tests/mdb.rs
+++ b/integration-tests/tests/mdb.rs
@@ -209,7 +209,24 @@ async fn pushdown_filters(#[case] source: RemoteSource) {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn list_tables() {
+async fn list_tables_basic() {
+    assert_result(
+        RemoteDbType::Mdb,
+        RemoteSource::Command(SourceCommand::ListMdbTables),
+        "select * from remote_table order by table_name limit 3",
+        r#"+-------------------------------+------------+
+| table_name                    | table_type |
++-------------------------------+------------+
+| Alphabetical List of Products | View       |
+| Catalog                       | View       |
+| Categories                    | Table      |
++-------------------------------+------------+"#,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_tables_projection_and_limit() {
     let options = build_conn_options(RemoteDbType::Mdb);
     let table = RemoteTable::try_new(options, RemoteSource::Command(SourceCommand::ListMdbTables))
         .await
@@ -218,21 +235,22 @@ async fn list_tables() {
     let ctx = SessionContext::new();
     ctx.register_table("remote_table", Arc::new(table)).unwrap();
 
-    // Verify the magic table returns table_name and table_type columns
-    // containing expected Northwind tables
+    // Projection: select only table_name column with a limit
     let df = ctx
-        .sql("select * from remote_table order by table_name")
+        .sql("select table_name from remote_table order by table_name limit 2")
         .await
         .unwrap();
     let result = collect(df.create_physical_plan().await.unwrap(), ctx.task_ctx())
         .await
         .unwrap();
     let formatted = pretty_format_batches(&result).unwrap().to_string();
-
-    // Northwind sample database should contain these well-known tables
-    assert!(formatted.contains("Shippers"));
-    assert!(formatted.contains("Products"));
-    assert!(formatted.contains("Table"));
-
-    println!("Tables in nwind.mdb:\n{formatted}");
+    assert_eq!(
+        formatted,
+        r#"+-------------------------------+
+| table_name                    |
++-------------------------------+
+| Alphabetical List of Products |
+| Catalog                       |
++-------------------------------+"#
+    );
 }

--- a/integration-tests/tests/mdb.rs
+++ b/integration-tests/tests/mdb.rs
@@ -3,8 +3,7 @@ use datafusion::physical_plan::collect;
 use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion_remote_table::{
-    ConnectionOptions, MDB_LIST_TABLES_MAGIC, MdbConnectionOptions, RemoteDbType, RemoteSource,
-    RemoteTable,
+    ConnectionOptions, MdbConnectionOptions, RemoteCommand, RemoteDbType, RemoteSource, RemoteTable,
 };
 use integration_tests::setup_mdb;
 use integration_tests::utils::{assert_plan_and_result, assert_result, build_conn_options};
@@ -73,6 +72,7 @@ async fn count1_agg(#[case] source: RemoteSource) {
             vec!["ProjectionExec: expr=[3 as count(*)]\n  PlaceholderRowExec\n"]
         }
         RemoteSource::Query(_) => vec![&query_plan],
+        RemoteSource::Command(_) => unreachable!("Command not used in this test"),
     };
     assert_plan_and_result(
         RemoteDbType::Mdb,
@@ -211,7 +211,7 @@ async fn pushdown_filters(#[case] source: RemoteSource) {
 #[tokio::test(flavor = "multi_thread")]
 async fn list_tables() {
     let options = build_conn_options(RemoteDbType::Mdb);
-    let table = RemoteTable::try_new(options, RemoteSource::from(vec![MDB_LIST_TABLES_MAGIC]))
+    let table = RemoteTable::try_new(options, RemoteSource::Command(RemoteCommand::ListMdbTables))
         .await
         .unwrap();
 

--- a/remote-table/gen/proto/remote_table.proto
+++ b/remote-table/gen/proto/remote_table.proto
@@ -60,11 +60,11 @@ message RemoteSource {
   oneof source {
     string query = 1;
     Identifiers table = 2;
-    RemoteCommand command = 3;
+    SourceCommand command = 3;
   }
 }
 
-message RemoteCommand {
+message SourceCommand {
   oneof command {
     Empty list_mdb_tables = 1;
   }

--- a/remote-table/gen/proto/remote_table.proto
+++ b/remote-table/gen/proto/remote_table.proto
@@ -60,6 +60,13 @@ message RemoteSource {
   oneof source {
     string query = 1;
     Identifiers table = 2;
+    RemoteCommand command = 3;
+  }
+}
+
+message RemoteCommand {
+  oneof command {
+    Empty list_mdb_tables = 1;
   }
 }
 

--- a/remote-table/src/codec.rs
+++ b/remote-table/src/codec.rs
@@ -8,8 +8,8 @@ use crate::SqliteConnectionOptions;
 use crate::generated::prost as protobuf;
 use crate::{
     ConnectionOptions, DFResult, DefaultLiteralizer, DefaultTransform, DmType, Literalize, MdbType,
-    MysqlType, OracleType, PostgresType, RemoteCommand, RemoteField, RemoteSchema, RemoteSchemaRef,
-    RemoteSource, RemoteTableInsertExec, RemoteTableScanExec, RemoteType, SqliteType, Transform,
+    MysqlType, OracleType, PostgresType, RemoteField, RemoteSchema, RemoteSchemaRef, RemoteSource,
+    RemoteTableInsertExec, RemoteTableScanExec, RemoteType, SourceCommand, SqliteType, Transform,
 };
 use arrow::datatypes::SchemaRef;
 use datafusion_common::DataFusionError;
@@ -1283,9 +1283,9 @@ fn parse_remote_type(remote_type: &protobuf::RemoteType) -> DFResult<RemoteType>
     })
 }
 
-fn serialize_remote_command(cmd: &RemoteCommand) -> protobuf::RemoteCommand {
+fn serialize_remote_command(cmd: &SourceCommand) -> protobuf::SourceCommand {
     match cmd {
-        RemoteCommand::ListMdbTables => protobuf::RemoteCommand {
+        SourceCommand::ListMdbTables => protobuf::SourceCommand {
             command: Some(protobuf::remote_command::Command::ListMdbTables(
                 protobuf::Empty {},
             )),
@@ -1293,12 +1293,12 @@ fn serialize_remote_command(cmd: &RemoteCommand) -> protobuf::RemoteCommand {
     }
 }
 
-fn parse_remote_command(cmd: &protobuf::RemoteCommand) -> DFResult<RemoteCommand> {
+fn parse_remote_command(cmd: &protobuf::SourceCommand) -> DFResult<SourceCommand> {
     let command = cmd.command.as_ref().ok_or(DataFusionError::Internal(
         "remote command is not set".to_string(),
     ))?;
     match command {
-        protobuf::remote_command::Command::ListMdbTables(_) => Ok(RemoteCommand::ListMdbTables),
+        protobuf::remote_command::Command::ListMdbTables(_) => Ok(SourceCommand::ListMdbTables),
     }
 }
 

--- a/remote-table/src/codec.rs
+++ b/remote-table/src/codec.rs
@@ -8,8 +8,8 @@ use crate::SqliteConnectionOptions;
 use crate::generated::prost as protobuf;
 use crate::{
     ConnectionOptions, DFResult, DefaultLiteralizer, DefaultTransform, DmType, Literalize, MdbType,
-    MysqlType, OracleType, PostgresType, RemoteField, RemoteSchema, RemoteSchemaRef, RemoteSource,
-    RemoteTableInsertExec, RemoteTableScanExec, RemoteType, SqliteType, Transform,
+    MysqlType, OracleType, PostgresType, RemoteCommand, RemoteField, RemoteSchema, RemoteSchemaRef,
+    RemoteSource, RemoteTableInsertExec, RemoteTableScanExec, RemoteType, SqliteType, Transform,
 };
 use arrow::datatypes::SchemaRef;
 use datafusion_common::DataFusionError;
@@ -1283,6 +1283,25 @@ fn parse_remote_type(remote_type: &protobuf::RemoteType) -> DFResult<RemoteType>
     })
 }
 
+fn serialize_remote_command(cmd: &RemoteCommand) -> protobuf::RemoteCommand {
+    match cmd {
+        RemoteCommand::ListMdbTables => protobuf::RemoteCommand {
+            command: Some(protobuf::remote_command::Command::ListMdbTables(
+                protobuf::Empty {},
+            )),
+        },
+    }
+}
+
+fn parse_remote_command(cmd: &protobuf::RemoteCommand) -> DFResult<RemoteCommand> {
+    let command = cmd.command.as_ref().ok_or(DataFusionError::Internal(
+        "remote command is not set".to_string(),
+    ))?;
+    match command {
+        protobuf::remote_command::Command::ListMdbTables(_) => Ok(RemoteCommand::ListMdbTables),
+    }
+}
+
 fn serialize_remote_source(source: &RemoteSource) -> protobuf::RemoteSource {
     match source {
         RemoteSource::Query(query) => protobuf::RemoteSource {
@@ -1293,6 +1312,11 @@ fn serialize_remote_source(source: &RemoteSource) -> protobuf::RemoteSource {
                 protobuf::Identifiers {
                     idents: table_identifiers.clone(),
                 },
+            )),
+        },
+        RemoteSource::Command(cmd) => protobuf::RemoteSource {
+            source: Some(protobuf::remote_source::Source::Command(
+                serialize_remote_command(cmd),
             )),
         },
     }
@@ -1306,6 +1330,9 @@ fn parse_remote_source(source: &protobuf::RemoteSource) -> DFResult<RemoteSource
         protobuf::remote_source::Source::Query(query) => Ok(RemoteSource::Query(query.clone())),
         protobuf::remote_source::Source::Table(table_identifiers) => {
             Ok(RemoteSource::Table(table_identifiers.idents.clone()))
+        }
+        protobuf::remote_source::Source::Command(cmd) => {
+            Ok(RemoteSource::Command(parse_remote_command(cmd)?))
         }
     }
 }

--- a/remote-table/src/connection/dm/mod.rs
+++ b/remote-table/src/connection/dm/mod.rs
@@ -89,6 +89,11 @@ impl Drop for DmConnection {
 #[async_trait::async_trait]
 impl Connection for DmConnection {
     async fn infer_schema(&self, source: &RemoteSource) -> DFResult<RemoteSchemaRef> {
+        if matches!(source, RemoteSource::Command(_)) {
+            return Err(DataFusionError::NotImplemented(
+                "Command is not supported for DM".to_string(),
+            ));
+        }
         let sql = RemoteDbType::Dm.limit_1_query_if_possible(source);
         let conn = self.conn.lock().await;
         let cursor_opt = conn.execute(&sql, (), None).map_err(|e| {

--- a/remote-table/src/connection/dm/mod.rs
+++ b/remote-table/src/connection/dm/mod.rs
@@ -94,7 +94,7 @@ impl Connection for DmConnection {
                 "Command is not supported for DM".to_string(),
             ));
         }
-        let sql = RemoteDbType::Dm.limit_1_query_if_possible(source);
+        let sql = RemoteDbType::Dm.limit_1_query_if_possible(source)?;
         let conn = self.conn.lock().await;
         let cursor_opt = conn.execute(&sql, (), None).map_err(|e| {
             DataFusionError::Plan(format!("Failed to execute query {sql} on dm: {e:?}"))

--- a/remote-table/src/connection/dm/mod.rs
+++ b/remote-table/src/connection/dm/mod.rs
@@ -89,11 +89,6 @@ impl Drop for DmConnection {
 #[async_trait::async_trait]
 impl Connection for DmConnection {
     async fn infer_schema(&self, source: &RemoteSource) -> DFResult<RemoteSchemaRef> {
-        if matches!(source, RemoteSource::Command(_)) {
-            return Err(DataFusionError::NotImplemented(
-                "Command is not supported for DM".to_string(),
-            ));
-        }
         let sql = RemoteDbType::Dm.limit_1_query_if_possible(source)?;
         let conn = self.conn.lock().await;
         let cursor_opt = conn.execute(&sql, (), None).map_err(|e| {

--- a/remote-table/src/connection/mdb/mod.rs
+++ b/remote-table/src/connection/mdb/mod.rs
@@ -3,12 +3,14 @@ mod schema;
 
 use crate::connection::ODBC_ENV;
 use crate::{
-    Connection, ConnectionOptions, DFResult, Literalize, MdbConnectionOptions, Pool, PoolState,
-    RemoteDbType, RemoteSchemaRef, RemoteSource,
+    Connection, ConnectionOptions, DFResult, Literalize, MdbConnectionOptions, MdbType, Pool,
+    PoolState, RemoteDbType, RemoteField, RemoteSchema, RemoteSchemaRef, RemoteSource, RemoteType,
 };
+use arrow::array::ArrayRef;
 use arrow::array::RecordBatch;
+use arrow::array::StringBuilder;
 use arrow::array::make_builder;
-use arrow::datatypes::SchemaRef;
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion_common::DataFusionError;
 use datafusion_common::project_schema;
 use datafusion_execution::SendableRecordBatchStream;
@@ -28,6 +30,49 @@ use tokio::runtime::Handle;
 use row::append_row_to_builders;
 use row::finish_batch;
 use schema::build_remote_schema;
+
+/// Magic virtual table name for listing user tables in an MDB file.
+///
+/// Create a [`RemoteTable`](crate::RemoteTable) with this name to query the
+/// list of tables in the `.mdb` file as if it were a real table with columns
+/// `table_name` (Utf8) and `table_type` (Utf8, either `"Table"` or `"View"`).
+///
+/// # Example
+///
+/// ```ignore
+/// let table = RemoteTable::try_new(
+///     ConnectionOptions::Mdb(options),
+///     RemoteSource::from(vec![MDB_LIST_TABLES_MAGIC.to_string()]),
+/// ).await?;
+/// ```
+pub const MDB_LIST_TABLES_MAGIC: &str = "__mdb_list_tables__";
+
+/// Check whether the source targets the magic list-tables virtual table.
+fn is_list_tables_source(source: &RemoteSource) -> bool {
+    matches!(source, RemoteSource::Table(t) if t.len() == 1 && t[0] == MDB_LIST_TABLES_MAGIC)
+}
+
+fn list_tables_arrow_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("table_name", DataType::Utf8, false),
+        Field::new("table_type", DataType::Utf8, false),
+    ]))
+}
+
+fn list_tables_remote_schema() -> RemoteSchema {
+    RemoteSchema::new(vec![
+        RemoteField::new(
+            "table_name",
+            RemoteType::Mdb(MdbType::Text(Some(255))),
+            false,
+        ),
+        RemoteField::new(
+            "table_type",
+            RemoteType::Mdb(MdbType::Text(Some(50))),
+            false,
+        ),
+    ])
+}
 
 /// Cache key that captures the full ODBC connection identity, not just the
 /// `.mdb` file path. Two pools that target the same path but use different
@@ -165,6 +210,10 @@ impl Drop for MdbConnection {
 #[async_trait::async_trait]
 impl Connection for MdbConnection {
     async fn infer_schema(&self, source: &RemoteSource) -> DFResult<RemoteSchemaRef> {
+        if is_list_tables_source(source) {
+            return Ok(Arc::new(list_tables_remote_schema()));
+        }
+
         let sql = RemoteDbType::Mdb.limit_1_query_if_possible(source);
         debug!("[remote-table] inferring mdb schema with: {sql}");
         let conn = self.conn.lock().await;
@@ -208,6 +257,12 @@ impl Connection for MdbConnection {
         unparsed_filters: &[String],
         limit: Option<usize>,
     ) -> DFResult<SendableRecordBatchStream> {
+        if is_list_tables_source(source) {
+            return self
+                .query_list_tables_impl(table_schema, projection, limit)
+                .await;
+        }
+
         let projected_schema = project_schema(&table_schema, projection)?;
 
         let sql = RemoteDbType::Mdb.rewrite_query(source, unparsed_filters, limit);
@@ -350,6 +405,11 @@ impl Connection for MdbConnection {
         source: &RemoteSource,
         unparsed_filters: &[String],
     ) -> DFResult<Option<usize>> {
+        if is_list_tables_source(source) {
+            let tables = self.list_tables().await?;
+            return Ok(Some(tables.len()));
+        }
+
         let db_type = conn_options.db_type();
         let source = if unparsed_filters.is_empty() {
             source.clone()
@@ -435,96 +495,139 @@ impl MdbConnection {
             DataFusionError::Execution(format!("Failed to join MDB row count task: {e}"))
         })?
     }
-}
 
-/// List user tables in an MDB file using the ODBC `SQLTables` function.
-///
-/// Returns `Vec<(table_name, table_type)>` where `table_type` is `"Table"` or `"View"`.
-/// System tables (prefixed with `MSys`) are filtered out.
-pub fn mdb_list_tables(options: &MdbConnectionOptions) -> DFResult<Vec<(String, String)>> {
-    let env = ODBC_ENV.get_or_init(|| Environment::new().expect("failed to create ODBC env"));
-    let connection_str = options.connection_string();
-    debug!("[remote-table] mdb_list_tables connection string: {connection_str}");
-    let conn = env
-        .connect_with_connection_string(&connection_str, odbc_api::ConnectionOptions::default())
-        .map_err(|e| {
+    /// Core: call ODBC SQLTables on an already-locked connection.
+    /// Returns (table_name, table_type), system tables filtered out.
+    fn list_tables_sync(conn: &odbc_api::Connection<'_>) -> DFResult<Vec<(String, String)>> {
+        let pre = conn.preallocate().map_err(|e| {
             DataFusionError::Execution(format!(
-                "Failed to create odbc connection for mdb_list_tables: {e:?}"
+                "Failed to preallocate statement for list_tables: {e:?}"
             ))
         })?;
+        let mut stmt = pre.into_handle();
 
-    let pre = conn.preallocate().map_err(|e| {
-        DataFusionError::Execution(format!(
-            "Failed to preallocate statement for mdb_list_tables: {e:?}"
-        ))
-    })?;
-    let mut stmt = pre.into_handle();
+        let sql_cat = SqlText::new("");
+        let sql_sch = SqlText::new("");
+        let sql_tbl = SqlText::new("%");
+        let sql_typ = SqlText::new("TABLE,VIEW");
+        stmt.tables(&sql_cat, &sql_sch, &sql_tbl, &sql_typ)
+            .into_result(&stmt)
+            .map_err(|e| {
+                DataFusionError::Execution(format!("Failed to execute SQLTables on mdb: {e:?}"))
+            })?;
 
-    // Call SQLTables via the Statement trait
-    let sql_cat = SqlText::new("");
-    let sql_sch = SqlText::new("");
-    let sql_tbl = SqlText::new("%");
-    let sql_typ = SqlText::new("TABLE,VIEW");
-    stmt.tables(&sql_cat, &sql_sch, &sql_tbl, &sql_typ)
-        .into_result(&stmt)
-        .map_err(|e| {
-            DataFusionError::Execution(format!("Failed to execute SQLTables on mdb: {e:?}"))
-        })?;
-
-    // Bind dummy column (mdbtools workaround: SQLFetch hangs without at
-    // least one bound column, same as the query path).
-    let mut dummy = odbc_api::Nullable::<i32>::null();
-    match unsafe { Statement::bind_col(&mut stmt, 1, &mut dummy) } {
-        SqlResult::Success(()) | SqlResult::SuccessWithInfo(()) => {}
-        other => {
-            return Err(DataFusionError::Execution(format!(
-                "Failed to bind dummy column for mdb_list_tables: {other:?}"
-            )));
+        // Bind dummy column (mdbtools workaround: SQLFetch hangs without at
+        // least one bound column, same as the query path).
+        let mut dummy = odbc_api::Nullable::<i32>::null();
+        match unsafe { Statement::bind_col(&mut stmt, 1, &mut dummy) } {
+            SqlResult::Success(()) | SqlResult::SuccessWithInfo(()) => {}
+            other => {
+                return Err(DataFusionError::Execution(format!(
+                    "Failed to bind dummy column for list_tables: {other:?}"
+                )));
+            }
         }
-    }
 
-    // SAFETY: stmt is in cursor state after a successful tables() call.
-    let mut cursor: CursorImpl<StatementImpl> = unsafe { CursorImpl::new(stmt) };
-    let mut tables = Vec::new();
-    let mut text_buf: Vec<u8> = Vec::new();
+        // SAFETY: stmt is in cursor state after a successful tables() call.
+        let mut cursor: CursorImpl<StatementImpl> = unsafe { CursorImpl::new(stmt) };
+        let mut tables = Vec::new();
+        let mut text_buf: Vec<u8> = Vec::new();
 
-    loop {
-        match cursor.next_row() {
-            Ok(Some(mut row)) => {
-                // Column 3 = TABLE_NAME
-                text_buf.clear();
-                if row.get_text(3, &mut text_buf).unwrap_or(false) {
-                    let table_name = String::from_utf8_lossy(&text_buf).into_owned();
-
-                    // Column 4 = TABLE_TYPE
+        loop {
+            match cursor.next_row() {
+                Ok(Some(mut row)) => {
+                    // Column 3 = TABLE_NAME
                     text_buf.clear();
-                    let table_type = if row.get_text(4, &mut text_buf).unwrap_or(false) {
-                        String::from_utf8_lossy(&text_buf).into_owned()
-                    } else {
-                        "TABLE".to_string()
-                    };
+                    if row.get_text(3, &mut text_buf).unwrap_or(false) {
+                        let table_name = String::from_utf8_lossy(&text_buf).into_owned();
 
-                    // Filter system/internal tables
-                    if !table_name.starts_with("MSys") && !table_name.starts_with("~") {
-                        let display_type = if table_type.eq_ignore_ascii_case("VIEW") {
-                            "View"
+                        // Column 4 = TABLE_TYPE
+                        text_buf.clear();
+                        let table_type = if row.get_text(4, &mut text_buf).unwrap_or(false) {
+                            String::from_utf8_lossy(&text_buf).into_owned()
                         } else {
-                            "Table"
+                            "TABLE".to_string()
                         };
-                        tables.push((table_name, display_type.to_string()));
+
+                        // Filter system/internal tables
+                        if !table_name.starts_with("MSys") && !table_name.starts_with("~") {
+                            let display_type = if table_type.eq_ignore_ascii_case("VIEW") {
+                                "View"
+                            } else {
+                                "Table"
+                            };
+                            tables.push((table_name, display_type.to_string()));
+                        }
                     }
                 }
-            }
-            Ok(None) => break,
-            Err(e) => {
-                return Err(DataFusionError::External(Box::new(e)));
+                Ok(None) => break,
+                Err(e) => {
+                    return Err(DataFusionError::External(Box::new(e)));
+                }
             }
         }
+
+        debug!("[remote-table] list_tables found {} tables", tables.len());
+        Ok(tables)
     }
 
-    debug!(
-        "[remote-table] mdb_list_tables found {} tables",
-        tables.len()
-    );
-    Ok(tables)
+    /// List user tables in the MDB file using the cached ODBC connection.
+    pub async fn list_tables(&self) -> DFResult<Vec<(String, String)>> {
+        let conn = Arc::clone(&self.conn);
+        tokio::task::spawn_blocking(move || {
+            let handle = Handle::current();
+            let guard = handle.block_on(async { conn.lock().await });
+            Self::list_tables_sync(&guard)
+        })
+        .await
+        .map_err(|e| DataFusionError::Execution(format!("Failed to join list_tables task: {e}")))?
+    }
+
+    /// Build a RecordBatch stream from the in-memory table list.
+    async fn query_list_tables_impl(
+        &self,
+        table_schema: SchemaRef,
+        projection: Option<&Vec<usize>>,
+        limit: Option<usize>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        let mut tables = self.list_tables().await?;
+        if let Some(lim) = limit {
+            tables.truncate(lim);
+        }
+
+        let mut name_builder = StringBuilder::new();
+        let mut type_builder = StringBuilder::new();
+        for (name, typ) in &tables {
+            name_builder.append_value(name);
+            type_builder.append_value(typ);
+        }
+
+        let full_schema = list_tables_arrow_schema();
+        let batch = RecordBatch::try_new(
+            full_schema.clone(),
+            vec![
+                Arc::new(name_builder.finish()),
+                Arc::new(type_builder.finish()),
+            ],
+        )?;
+
+        let projected_schema = project_schema(&table_schema, projection)?;
+        let output_batch = match projection {
+            Some(indices) => {
+                let columns: Vec<ArrayRef> =
+                    indices.iter().map(|&i| batch.column(i).clone()).collect();
+                RecordBatch::try_new(projected_schema.clone(), columns)?
+            }
+            None => batch,
+        };
+
+        let output_stream = async_stream::stream! {
+            yield Ok(output_batch);
+        };
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            projected_schema,
+            output_stream,
+        )))
+    }
 }

--- a/remote-table/src/connection/mdb/mod.rs
+++ b/remote-table/src/connection/mdb/mod.rs
@@ -4,7 +4,8 @@ mod schema;
 use crate::connection::ODBC_ENV;
 use crate::{
     Connection, ConnectionOptions, DFResult, Literalize, MdbConnectionOptions, MdbType, Pool,
-    PoolState, RemoteDbType, RemoteField, RemoteSchema, RemoteSchemaRef, RemoteSource, RemoteType,
+    PoolState, RemoteCommand, RemoteDbType, RemoteField, RemoteSchema, RemoteSchemaRef,
+    RemoteSource, RemoteType,
 };
 use arrow::array::ArrayRef;
 use arrow::array::RecordBatch;
@@ -30,27 +31,6 @@ use tokio::runtime::Handle;
 use row::append_row_to_builders;
 use row::finish_batch;
 use schema::build_remote_schema;
-
-/// Magic virtual table name for listing user tables in an MDB file.
-///
-/// Create a [`RemoteTable`](crate::RemoteTable) with this name to query the
-/// list of tables in the `.mdb` file as if it were a real table with columns
-/// `table_name` (Utf8) and `table_type` (Utf8, either `"Table"` or `"View"`).
-///
-/// # Example
-///
-/// ```ignore
-/// let table = RemoteTable::try_new(
-///     ConnectionOptions::Mdb(options),
-///     RemoteSource::from(vec![MDB_LIST_TABLES_MAGIC.to_string()]),
-/// ).await?;
-/// ```
-pub const MDB_LIST_TABLES_MAGIC: &str = "__mdb_list_tables__";
-
-/// Check whether the source targets the magic list-tables virtual table.
-fn is_list_tables_source(source: &RemoteSource) -> bool {
-    matches!(source, RemoteSource::Table(t) if t.len() == 1 && t[0] == MDB_LIST_TABLES_MAGIC)
-}
 
 fn list_tables_arrow_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
@@ -210,7 +190,7 @@ impl Drop for MdbConnection {
 #[async_trait::async_trait]
 impl Connection for MdbConnection {
     async fn infer_schema(&self, source: &RemoteSource) -> DFResult<RemoteSchemaRef> {
-        if is_list_tables_source(source) {
+        if matches!(source, RemoteSource::Command(RemoteCommand::ListMdbTables)) {
             return Ok(Arc::new(list_tables_remote_schema()));
         }
 
@@ -257,7 +237,7 @@ impl Connection for MdbConnection {
         unparsed_filters: &[String],
         limit: Option<usize>,
     ) -> DFResult<SendableRecordBatchStream> {
-        if is_list_tables_source(source) {
+        if matches!(source, RemoteSource::Command(RemoteCommand::ListMdbTables)) {
             return self
                 .query_list_tables_impl(table_schema, projection, limit)
                 .await;
@@ -405,7 +385,7 @@ impl Connection for MdbConnection {
         source: &RemoteSource,
         unparsed_filters: &[String],
     ) -> DFResult<Option<usize>> {
-        if is_list_tables_source(source) {
+        if matches!(source, RemoteSource::Command(RemoteCommand::ListMdbTables)) {
             let tables = self.list_tables().await?;
             return Ok(Some(tables.len()));
         }

--- a/remote-table/src/connection/mdb/mod.rs
+++ b/remote-table/src/connection/mdb/mod.rs
@@ -4,8 +4,8 @@ mod schema;
 use crate::connection::ODBC_ENV;
 use crate::{
     Connection, ConnectionOptions, DFResult, Literalize, MdbConnectionOptions, MdbType, Pool,
-    PoolState, RemoteCommand, RemoteDbType, RemoteField, RemoteSchema, RemoteSchemaRef,
-    RemoteSource, RemoteType,
+    PoolState, RemoteDbType, RemoteField, RemoteSchema, RemoteSchemaRef, RemoteSource, RemoteType,
+    SourceCommand,
 };
 use arrow::array::ArrayRef;
 use arrow::array::RecordBatch;
@@ -190,7 +190,7 @@ impl Drop for MdbConnection {
 #[async_trait::async_trait]
 impl Connection for MdbConnection {
     async fn infer_schema(&self, source: &RemoteSource) -> DFResult<RemoteSchemaRef> {
-        if matches!(source, RemoteSource::Command(RemoteCommand::ListMdbTables)) {
+        if matches!(source, RemoteSource::Command(SourceCommand::ListMdbTables)) {
             return Ok(Arc::new(list_tables_remote_schema()));
         }
 
@@ -237,7 +237,7 @@ impl Connection for MdbConnection {
         unparsed_filters: &[String],
         limit: Option<usize>,
     ) -> DFResult<SendableRecordBatchStream> {
-        if matches!(source, RemoteSource::Command(RemoteCommand::ListMdbTables)) {
+        if matches!(source, RemoteSource::Command(SourceCommand::ListMdbTables)) {
             return self
                 .query_list_tables_impl(table_schema, projection, limit)
                 .await;
@@ -385,7 +385,7 @@ impl Connection for MdbConnection {
         source: &RemoteSource,
         unparsed_filters: &[String],
     ) -> DFResult<Option<usize>> {
-        if matches!(source, RemoteSource::Command(RemoteCommand::ListMdbTables)) {
+        if matches!(source, RemoteSource::Command(SourceCommand::ListMdbTables)) {
             let tables = self.list_tables().await?;
             return Ok(Some(tables.len()));
         }

--- a/remote-table/src/connection/mdb/mod.rs
+++ b/remote-table/src/connection/mdb/mod.rs
@@ -11,7 +11,7 @@ use arrow::array::ArrayRef;
 use arrow::array::RecordBatch;
 use arrow::array::StringBuilder;
 use arrow::array::make_builder;
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::datatypes::SchemaRef;
 use datafusion_common::DataFusionError;
 use datafusion_common::project_schema;
 use datafusion_execution::SendableRecordBatchStream;
@@ -31,13 +31,6 @@ use tokio::runtime::Handle;
 use row::append_row_to_builders;
 use row::finish_batch;
 use schema::build_remote_schema;
-
-fn list_tables_arrow_schema() -> SchemaRef {
-    Arc::new(Schema::new(vec![
-        Field::new("table_name", DataType::Utf8, false),
-        Field::new("table_type", DataType::Utf8, false),
-    ]))
-}
 
 fn list_tables_remote_schema() -> RemoteSchema {
     RemoteSchema::new(vec![
@@ -582,7 +575,7 @@ impl MdbConnection {
             type_builder.append_value(typ);
         }
 
-        let full_schema = list_tables_arrow_schema();
+        let full_schema = Arc::new(list_tables_remote_schema().to_arrow_schema());
         let batch = RecordBatch::try_new(
             full_schema.clone(),
             vec![

--- a/remote-table/src/connection/mdb/mod.rs
+++ b/remote-table/src/connection/mdb/mod.rs
@@ -194,7 +194,7 @@ impl Connection for MdbConnection {
             return Ok(Arc::new(list_tables_remote_schema()));
         }
 
-        let sql = RemoteDbType::Mdb.limit_1_query_if_possible(source);
+        let sql = RemoteDbType::Mdb.limit_1_query_if_possible(source)?;
         debug!("[remote-table] inferring mdb schema with: {sql}");
         let conn = self.conn.lock().await;
         // mdbtools 1.0.0 does not support SQL_ATTR_PARAMSET_SIZE, and

--- a/remote-table/src/connection/mod.rs
+++ b/remote-table/src/connection/mod.rs
@@ -354,9 +354,7 @@ impl RemoteDbType {
                     }
                 }
             },
-            RemoteSource::Command(_) => unreachable!(
-                "rewrite_query called on Command: support_rewrite_with_filters_limit should return false"
-            ),
+            RemoteSource::Command(_) => String::new(),
         }
     }
 
@@ -416,11 +414,11 @@ impl RemoteDbType {
         }
     }
 
-    pub(crate) fn limit_1_query_if_possible(&self, source: &RemoteSource) -> String {
+    pub(crate) fn limit_1_query_if_possible(&self, source: &RemoteSource) -> DFResult<String> {
         if !self.support_rewrite_with_filters_limit(source) {
             return source.query(*self);
         }
-        self.rewrite_query(source, &[], Some(1))
+        Ok(self.rewrite_query(source, &[], Some(1)))
     }
 
     pub(crate) fn try_count1_query(&self, source: &RemoteSource) -> Option<String> {

--- a/remote-table/src/connection/mod.rs
+++ b/remote-table/src/connection/mod.rs
@@ -224,6 +224,7 @@ impl RemoteDbType {
             _ => match source {
                 RemoteSource::Table(_) => true,
                 RemoteSource::Query(query) => query.trim()[0..6].eq_ignore_ascii_case("select"),
+                RemoteSource::Command(_) => false,
             },
         }
     }
@@ -353,6 +354,9 @@ impl RemoteDbType {
                     }
                 }
             },
+            RemoteSource::Command(_) => unreachable!(
+                "rewrite_query called on Command: support_rewrite_with_filters_limit should return false"
+            ),
         }
     }
 
@@ -440,6 +444,7 @@ impl RemoteDbType {
                     RemoteDbType::Oracle => Some(format!("SELECT COUNT(1) FROM ({query})")),
                     RemoteDbType::Mdb => unreachable!(),
                 },
+                RemoteSource::Command(_) => None,
             },
         }
     }

--- a/remote-table/src/connection/mysql.rs
+++ b/remote-table/src/connection/mysql.rs
@@ -86,7 +86,7 @@ impl Connection for MysqlConnection {
                 "Command is not supported for MySQL".to_string(),
             ));
         }
-        let sql = RemoteDbType::Mysql.limit_1_query_if_possible(source);
+        let sql = RemoteDbType::Mysql.limit_1_query_if_possible(source)?;
         let mut conn = self.conn.lock().await;
         let conn = &mut *conn;
         let stmt = conn.prep(&sql).await.map_err(|e| {

--- a/remote-table/src/connection/mysql.rs
+++ b/remote-table/src/connection/mysql.rs
@@ -81,6 +81,11 @@ pub struct MysqlConnection {
 #[async_trait::async_trait]
 impl Connection for MysqlConnection {
     async fn infer_schema(&self, source: &RemoteSource) -> DFResult<RemoteSchemaRef> {
+        if matches!(source, RemoteSource::Command(_)) {
+            return Err(DataFusionError::NotImplemented(
+                "Command is not supported for MySQL".to_string(),
+            ));
+        }
         let sql = RemoteDbType::Mysql.limit_1_query_if_possible(source);
         let mut conn = self.conn.lock().await;
         let conn = &mut *conn;

--- a/remote-table/src/connection/mysql.rs
+++ b/remote-table/src/connection/mysql.rs
@@ -81,11 +81,6 @@ pub struct MysqlConnection {
 #[async_trait::async_trait]
 impl Connection for MysqlConnection {
     async fn infer_schema(&self, source: &RemoteSource) -> DFResult<RemoteSchemaRef> {
-        if matches!(source, RemoteSource::Command(_)) {
-            return Err(DataFusionError::NotImplemented(
-                "Command is not supported for MySQL".to_string(),
-            ));
-        }
         let sql = RemoteDbType::Mysql.limit_1_query_if_possible(source)?;
         let mut conn = self.conn.lock().await;
         let conn = &mut *conn;

--- a/remote-table/src/connection/oracle.rs
+++ b/remote-table/src/connection/oracle.rs
@@ -82,7 +82,7 @@ impl Connection for OracleConnection {
                 "Command is not supported for Oracle".to_string(),
             ));
         }
-        let sql = RemoteDbType::Oracle.limit_1_query_if_possible(source);
+        let sql = RemoteDbType::Oracle.limit_1_query_if_possible(source)?;
         let result_set = self.conn.query(&sql, &[]).map_err(|e| {
             DataFusionError::Plan(format!("Failed to execute query {sql} on oracle: {e:?}"))
         })?;

--- a/remote-table/src/connection/oracle.rs
+++ b/remote-table/src/connection/oracle.rs
@@ -77,6 +77,11 @@ pub struct OracleConnection {
 #[async_trait::async_trait]
 impl Connection for OracleConnection {
     async fn infer_schema(&self, source: &RemoteSource) -> DFResult<RemoteSchemaRef> {
+        if matches!(source, RemoteSource::Command(_)) {
+            return Err(DataFusionError::NotImplemented(
+                "Command is not supported for Oracle".to_string(),
+            ));
+        }
         let sql = RemoteDbType::Oracle.limit_1_query_if_possible(source);
         let result_set = self.conn.query(&sql, &[]).map_err(|e| {
             DataFusionError::Plan(format!("Failed to execute query {sql} on oracle: {e:?}"))

--- a/remote-table/src/connection/oracle.rs
+++ b/remote-table/src/connection/oracle.rs
@@ -77,11 +77,6 @@ pub struct OracleConnection {
 #[async_trait::async_trait]
 impl Connection for OracleConnection {
     async fn infer_schema(&self, source: &RemoteSource) -> DFResult<RemoteSchemaRef> {
-        if matches!(source, RemoteSource::Command(_)) {
-            return Err(DataFusionError::NotImplemented(
-                "Command is not supported for Oracle".to_string(),
-            ));
-        }
         let sql = RemoteDbType::Oracle.limit_1_query_if_possible(source)?;
         let result_set = self.conn.query(&sql, &[]).map_err(|e| {
             DataFusionError::Plan(format!("Failed to execute query {sql} on oracle: {e:?}"))

--- a/remote-table/src/connection/postgres.rs
+++ b/remote-table/src/connection/postgres.rs
@@ -166,6 +166,9 @@ order by ordinal_position",
                 );
                 Ok(remote_schema)
             }
+            RemoteSource::Command(cmd) => Err(DataFusionError::NotImplemented(format!(
+                "Command {cmd:?} is not supported for Postgres"
+            ))),
         }
     }
 

--- a/remote-table/src/connection/sqlite.rs
+++ b/remote-table/src/connection/sqlite.rs
@@ -91,7 +91,7 @@ impl Connection for SqliteConnection {
                 Ok(remote_schema)
             }
             RemoteSource::Query(_query) => {
-                let sql = RemoteDbType::Sqlite.limit_1_query_if_possible(source);
+                let sql = RemoteDbType::Sqlite.limit_1_query_if_possible(source)?;
                 let mut stmt = conn.prepare(&sql).map_err(|e| {
                     DataFusionError::Plan(format!("Failed to prepare sqlite statement: {e:?}"))
                 })?;

--- a/remote-table/src/connection/sqlite.rs
+++ b/remote-table/src/connection/sqlite.rs
@@ -105,6 +105,9 @@ impl Connection for SqliteConnection {
                     Arc::new(build_remote_schema_for_query(columns.as_slice(), rows)?);
                 Ok(remote_schema)
             }
+            RemoteSource::Command(cmd) => Err(DataFusionError::NotImplemented(format!(
+                "Command {cmd:?} is not supported for SQLite"
+            ))),
         }
     }
 

--- a/remote-table/src/generated/prost.rs
+++ b/remote-table/src/generated/prost.rs
@@ -99,8 +99,21 @@ pub struct MdbExtraParam {
     pub value: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct RemoteCommand {
+    #[prost(oneof = "remote_command::Command", tags = "1")]
+    pub command: ::core::option::Option<remote_command::Command>,
+}
+/// Nested message and enum types in `RemoteCommand`.
+pub mod remote_command {
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum Command {
+        #[prost(message, tag = "1")]
+        ListMdbTables(super::Empty),
+    }
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RemoteSource {
-    #[prost(oneof = "remote_source::Source", tags = "1, 2")]
+    #[prost(oneof = "remote_source::Source", tags = "1, 2, 3")]
     pub source: ::core::option::Option<remote_source::Source>,
 }
 /// Nested message and enum types in `RemoteSource`.
@@ -111,6 +124,8 @@ pub mod remote_source {
         Query(::prost::alloc::string::String),
         #[prost(message, tag = "2")]
         Table(super::Identifiers),
+        #[prost(message, tag = "3")]
+        Command(super::RemoteCommand),
     }
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]

--- a/remote-table/src/generated/prost.rs
+++ b/remote-table/src/generated/prost.rs
@@ -99,11 +99,11 @@ pub struct MdbExtraParam {
     pub value: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct RemoteCommand {
+pub struct SourceCommand {
     #[prost(oneof = "remote_command::Command", tags = "1")]
     pub command: ::core::option::Option<remote_command::Command>,
 }
-/// Nested message and enum types in `RemoteCommand`.
+/// Nested message and enum types in `SourceCommand`.
 pub mod remote_command {
     #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
     pub enum Command {
@@ -125,7 +125,7 @@ pub mod remote_source {
         #[prost(message, tag = "2")]
         Table(super::Identifiers),
         #[prost(message, tag = "3")]
-        Command(super::RemoteCommand),
+        Command(super::SourceCommand),
     }
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]

--- a/remote-table/src/scan.rs
+++ b/remote-table/src/scan.rs
@@ -252,6 +252,7 @@ impl DisplayAs for RemoteTableScanExec {
             match &self.source {
                 RemoteSource::Query(_query) => "query".to_string(),
                 RemoteSource::Table(table) => table.join("."),
+                RemoteSource::Command(cmd) => format!("command:{cmd:?}"),
             }
         )?;
         let projected_schema = self.schema();

--- a/remote-table/src/table.rs
+++ b/remote-table/src/table.rs
@@ -31,13 +31,15 @@ pub enum RemoteSource {
 }
 
 impl RemoteSource {
-    pub fn query(&self, db_type: RemoteDbType) -> String {
+    pub fn query(&self, db_type: RemoteDbType) -> DFResult<String> {
         match self {
-            RemoteSource::Query(query) => query.clone(),
-            RemoteSource::Table(table_identifiers) => db_type.select_all_query(table_identifiers),
-            RemoteSource::Command(_) => {
-                unreachable!("Commands should be handled before query() is called")
+            RemoteSource::Query(query) => Ok(query.clone()),
+            RemoteSource::Table(table_identifiers) => {
+                Ok(db_type.select_all_query(table_identifiers))
             }
+            RemoteSource::Command(cmd) => Err(DataFusionError::NotImplemented(format!(
+                "Command {cmd:?} cannot be converted to a SQL query"
+            ))),
         }
     }
 }

--- a/remote-table/src/table.rs
+++ b/remote-table/src/table.rs
@@ -18,9 +18,16 @@ use std::sync::Arc;
 use tokio::sync::OnceCell;
 
 #[derive(Debug, Clone)]
+pub enum RemoteCommand {
+    /// List all user tables/views in an MDB file.
+    ListMdbTables,
+}
+
+#[derive(Debug, Clone)]
 pub enum RemoteSource {
     Query(String),
     Table(Vec<String>),
+    Command(RemoteCommand),
 }
 
 impl RemoteSource {
@@ -28,6 +35,9 @@ impl RemoteSource {
         match self {
             RemoteSource::Query(query) => query.clone(),
             RemoteSource::Table(table_identifiers) => db_type.select_all_query(table_identifiers),
+            RemoteSource::Command(_) => {
+                unreachable!("Commands should be handled before query() is called")
+            }
         }
     }
 }
@@ -37,6 +47,7 @@ impl std::fmt::Display for RemoteSource {
         match self {
             RemoteSource::Query(query) => write!(f, "{query}"),
             RemoteSource::Table(table) => write!(f, "{}", table.join(".")),
+            RemoteSource::Command(cmd) => write!(f, "{cmd:?}"),
         }
     }
 }

--- a/remote-table/src/table.rs
+++ b/remote-table/src/table.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use tokio::sync::OnceCell;
 
 #[derive(Debug, Clone)]
-pub enum RemoteCommand {
+pub enum SourceCommand {
     /// List all user tables/views in an MDB file.
     ListMdbTables,
 }
@@ -27,7 +27,7 @@ pub enum RemoteCommand {
 pub enum RemoteSource {
     Query(String),
     Table(Vec<String>),
-    Command(RemoteCommand),
+    Command(SourceCommand),
 }
 
 impl RemoteSource {


### PR DESCRIPTION
- Move standalone mdb_list_tables into MdbConnection as list_tables_sync and pub async fn list_tables, reusing the cached ODBC connection
- Add __mdb_list_tables__ magic table name as public const MDB_LIST_TABLES_MAGIC, intercepted in infer_schema/query/count
- query_list_tables_impl builds RecordBatch stream from in-memory table list
- Add is_list_tables_source helper to avoid repetitive pattern matching
- Remove old uncalled pub fn mdb_list_tables standalone function
- Add integration test for list_tables with nwind.mdb fixture