### PR TITLE
refactor: change rewrite_query to return DFResult, error on Command source

### DIFF
--- a/integration-tests/tests/mdb.rs
+++ b/integration-tests/tests/mdb.rs
@@ -59,14 +59,13 @@ async fn pushdown_limit(#[case] source: RemoteSource) {
 async fn count1_agg(#[case] source: RemoteSource) {
     // Table source: COUNT pushdown via MDB row-count fast path
     // Query source: COUNT via DataFusion aggregate (no pushdown)
-    let query_plan = format!(
-        "ProjectionExec: expr=[count(Int64(1))@0 as count(*)]\n  \
+    let query_plan = "ProjectionExec: expr=[count(Int64(1))@0 as count(*)]\n  \
          AggregateExec: mode=Final, gby=[], aggr=[count(Int64(1))]\n    \
          CoalescePartitionsExec\n      \
          AggregateExec: mode=Partial, gby=[], aggr=[count(Int64(1))]\n        \
          RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1\n          \
          RemoteTableScanExec: source=query, projection=[]\n"
-    );
+        .to_string();
     let expected_plans: Vec<&str> = match &source {
         RemoteSource::Table(_) => {
             vec!["ProjectionExec: expr=[3 as count(*)]\n  PlaceholderRowExec\n"]

--- a/remote-table/src/connection/dm/mod.rs
+++ b/remote-table/src/connection/dm/mod.rs
@@ -116,7 +116,7 @@ impl Connection for DmConnection {
     ) -> DFResult<SendableRecordBatchStream> {
         let projected_schema = project_schema(&table_schema, projection)?;
 
-        let sql = RemoteDbType::Dm.rewrite_query(source, unparsed_filters, limit);
+        let sql = RemoteDbType::Dm.rewrite_query(source, unparsed_filters, limit)?;
         debug!("[remote-table] executing dm query: {sql}");
 
         let chunk_size = conn_options.stream_chunk_size();

--- a/remote-table/src/connection/mdb/mod.rs
+++ b/remote-table/src/connection/mdb/mod.rs
@@ -238,7 +238,7 @@ impl Connection for MdbConnection {
 
         let projected_schema = project_schema(&table_schema, projection)?;
 
-        let sql = RemoteDbType::Mdb.rewrite_query(source, unparsed_filters, limit);
+        let sql = RemoteDbType::Mdb.rewrite_query(source, unparsed_filters, limit)?;
         debug!("[remote-table] executing mdb query: {sql}");
 
         let chunk_size = conn_options.stream_chunk_size();
@@ -387,7 +387,7 @@ impl Connection for MdbConnection {
         let source = if unparsed_filters.is_empty() {
             source.clone()
         } else {
-            RemoteSource::Query(db_type.rewrite_query(source, unparsed_filters, None))
+            RemoteSource::Query(db_type.rewrite_query(source, unparsed_filters, None)?)
         };
         // MDB only supports COUNT on table sources
         if let RemoteSource::Table(table) = &source {

--- a/remote-table/src/connection/mod.rs
+++ b/remote-table/src/connection/mod.rs
@@ -100,7 +100,7 @@ pub(crate) async fn connection_count(
     let source = if unparsed_filters.is_empty() {
         source.clone()
     } else {
-        RemoteSource::Query(db_type.rewrite_query(source, unparsed_filters, None))
+        RemoteSource::Query(db_type.rewrite_query(source, unparsed_filters, None)?)
     };
     if let Some(count1_query) = db_type.try_count1_query(&source) {
         debug!("[remote-table] fetching row count with query: {count1_query}");
@@ -249,7 +249,7 @@ impl RemoteDbType {
         source: &RemoteSource,
         unparsed_filters: &[String],
         limit: Option<usize>,
-    ) -> String {
+    ) -> DFResult<String> {
         match source {
             RemoteSource::Table(table) => match self {
                 RemoteDbType::Postgres
@@ -267,10 +267,10 @@ impl RemoteDbType {
                         "".to_string()
                     };
 
-                    format!(
+                    Ok(format!(
                         "{}{where_clause}{limit_clause}",
                         self.select_all_query(table)
-                    )
+                    ))
                 }
                 RemoteDbType::Mdb => {
                     let where_clause = if unparsed_filters.is_empty() {
@@ -292,10 +292,10 @@ impl RemoteDbType {
                         "".to_string()
                     };
 
-                    format!(
+                    Ok(format!(
                         "{}{where_clause}{limit_clause}",
                         self.select_all_query(table)
-                    )
+                    ))
                 }
                 RemoteDbType::Oracle => {
                     let mut all_filters: Vec<String> = vec![];
@@ -309,7 +309,7 @@ impl RemoteDbType {
                     } else {
                         format!(" WHERE {}", all_filters.join(" AND "))
                     };
-                    format!("{}{where_clause}", self.select_all_query(table))
+                    Ok(format!("{}{where_clause}", self.select_all_query(table)))
                 }
             },
             RemoteSource::Query(query) => match self {
@@ -330,9 +330,9 @@ impl RemoteDbType {
                     };
 
                     if where_clause.is_empty() && limit_clause.is_empty() {
-                        query.clone()
+                        Ok(query.clone())
                     } else {
-                        format!("SELECT * FROM ({query}) as __subquery{where_clause}{limit_clause}")
+                        Ok(format!("SELECT * FROM ({query}) as __subquery{where_clause}{limit_clause}"))
                     }
                 }
                 RemoteDbType::Oracle => {
@@ -348,13 +348,15 @@ impl RemoteDbType {
                         format!(" WHERE {}", all_filters.join(" AND "))
                     };
                     if where_clause.is_empty() {
-                        query.clone()
+                        Ok(query.clone())
                     } else {
-                        format!("SELECT * FROM ({query}){where_clause}")
+                        Ok(format!("SELECT * FROM ({query}){where_clause}"))
                     }
                 }
             },
-            RemoteSource::Command(_) => String::new(),
+            RemoteSource::Command(cmd) => Err(DataFusionError::NotImplemented(format!(
+                "Command {cmd:?} cannot be rewritten to a SQL query"
+            ))),
         }
     }
 
@@ -418,7 +420,7 @@ impl RemoteDbType {
         if !self.support_rewrite_with_filters_limit(source) {
             return source.query(*self);
         }
-        Ok(self.rewrite_query(source, &[], Some(1)))
+        self.rewrite_query(source, &[], Some(1))
     }
 
     pub(crate) fn try_count1_query(&self, source: &RemoteSource) -> Option<String> {

--- a/remote-table/src/connection/mod.rs
+++ b/remote-table/src/connection/mod.rs
@@ -332,7 +332,9 @@ impl RemoteDbType {
                     if where_clause.is_empty() && limit_clause.is_empty() {
                         Ok(query.clone())
                     } else {
-                        Ok(format!("SELECT * FROM ({query}) as __subquery{where_clause}{limit_clause}"))
+                        Ok(format!(
+                            "SELECT * FROM ({query}) as __subquery{where_clause}{limit_clause}"
+                        ))
                     }
                 }
                 RemoteDbType::Oracle => {

--- a/remote-table/src/connection/mysql.rs
+++ b/remote-table/src/connection/mysql.rs
@@ -102,7 +102,7 @@ impl Connection for MysqlConnection {
     ) -> DFResult<SendableRecordBatchStream> {
         let projected_schema = project_schema(&table_schema, projection)?;
 
-        let sql = RemoteDbType::Mysql.rewrite_query(source, unparsed_filters, limit);
+        let sql = RemoteDbType::Mysql.rewrite_query(source, unparsed_filters, limit)?;
         debug!("[remote-table] executing mysql query: {sql}");
 
         let projection = projection.cloned();

--- a/remote-table/src/connection/oracle.rs
+++ b/remote-table/src/connection/oracle.rs
@@ -96,7 +96,7 @@ impl Connection for OracleConnection {
     ) -> DFResult<SendableRecordBatchStream> {
         let projected_schema = project_schema(&table_schema, projection)?;
 
-        let sql = RemoteDbType::Oracle.rewrite_query(source, unparsed_filters, limit);
+        let sql = RemoteDbType::Oracle.rewrite_query(source, unparsed_filters, limit)?;
         debug!("[remote-table] executing oracle query: {sql}");
 
         let projection = projection.cloned();

--- a/remote-table/src/connection/postgres.rs
+++ b/remote-table/src/connection/postgres.rs
@@ -183,7 +183,7 @@ order by ordinal_position",
     ) -> DFResult<SendableRecordBatchStream> {
         let projected_schema = project_schema(&table_schema, projection)?;
 
-        let sql = RemoteDbType::Postgres.rewrite_query(source, unparsed_filters, limit);
+        let sql = RemoteDbType::Postgres.rewrite_query(source, unparsed_filters, limit)?;
         debug!("[remote-table] executing postgres query: {sql}");
 
         let projection = projection.cloned();

--- a/remote-table/src/connection/sqlite.rs
+++ b/remote-table/src/connection/sqlite.rs
@@ -121,7 +121,7 @@ impl Connection for SqliteConnection {
         limit: Option<usize>,
     ) -> DFResult<SendableRecordBatchStream> {
         let projected_schema = project_schema(&table_schema, projection)?;
-        let sql = RemoteDbType::Sqlite.rewrite_query(source, unparsed_filters, limit);
+        let sql = RemoteDbType::Sqlite.rewrite_query(source, unparsed_filters, limit)?;
         debug!("[remote-table] executing sqlite query: {sql}");
 
         let (tx, mut rx) = tokio::sync::mpsc::channel::<DFResult<RecordBatch>>(1);


### PR DESCRIPTION
## Summary
- Change `rewrite_query` return type from `String` to `DFResult<String>`
- `RemoteSource::Command` now returns `Err(DataFusionError::NotImplemented(...))` instead of silently returning an empty string
- Update all 8 call sites to propagate the error with `?`

## Changes
7 files, +22/-20

## Verification
- ✅ `cargo check` passes
- ✅ `cargo test -p datafusion-remote-table` (4 unit tests pass)
- ⚠️ DM integration tests fail due to missing DM8 ODBC driver on this machine (unrelated to this change)