### PR TITLE
refactor(mdb): use safe conn.prepare() for infer_schema

### DIFF
--- a/remote-table/src/connection/mdb/mod.rs
+++ b/remote-table/src/connection/mdb/mod.rs
@@ -195,6 +195,15 @@ impl Connection for MdbConnection {
                 "Failed to prepare query for schema inference on mdb: {e:?}, sql: {sql}"
             ))
         })?;
+        // mdbtools does not populate result-set metadata (SQLNumResultCols /
+        // SQLDescribeCol) until after SQLExecute. Prepared::execute(()) is the
+        // safe wrapper around SQLExecute; we discard the returned cursor since
+        // column metadata is then available on `prepared` itself.
+        prepared.execute(()).map_err(|e| {
+            DataFusionError::Plan(format!(
+                "Failed to execute query for schema inference on mdb: {e:?}, sql: {sql}"
+            ))
+        })?;
         let remote_schema = Arc::new(build_remote_schema(&mut prepared)?);
         Ok(remote_schema)
     }

--- a/remote-table/src/connection/mdb/mod.rs
+++ b/remote-table/src/connection/mdb/mod.rs
@@ -190,34 +190,12 @@ impl Connection for MdbConnection {
         let sql = RemoteDbType::Mdb.limit_1_query_if_possible(source)?;
         debug!("[remote-table] inferring mdb schema with: {sql}");
         let conn = self.conn.lock().await;
-        // mdbtools 1.0.0 does not support SQL_ATTR_PARAMSET_SIZE, and
-        // `SQLExecDirect` + `SQLFetch` hangs. Use SQLPrepare + SQLExecute.
-        let pre = conn.preallocate().map_err(|e| {
+        let mut prepared = conn.prepare(&sql).map_err(|e| {
             DataFusionError::Plan(format!(
-                "Failed to preallocate statement for schema inference on mdb: {e:?}, sql: {sql}"
+                "Failed to prepare query for schema inference on mdb: {e:?}, sql: {sql}"
             ))
         })?;
-        let mut stmt = pre.into_handle();
-        let sql_text = SqlText::new(&sql);
-        // SAFETY: `sql` is owned by this stack frame and outlives `stmt` (which
-        // is consumed by `CursorImpl::new` below), so the `SqlText` borrow is
-        // valid for the duration of the prepare + execute. `prepare` is safe;
-        // `execute` is unsafe (may deref bound parameters; we have none).
-        if stmt.prepare(&sql_text).is_err() {
-            return Err(DataFusionError::Plan(format!(
-                "Failed to prepare query for schema inference on mdb: {sql}"
-            )));
-        }
-        if unsafe { stmt.execute() }.is_err() {
-            return Err(DataFusionError::Plan(format!(
-                "Failed to execute query for schema inference on mdb: {sql}"
-            )));
-        }
-        // SAFETY: `stmt` is in cursor state after a successful execute that
-        // produced a result set; we verify with num_result_cols() in
-        // build_remote_schema.
-        let cursor = unsafe { CursorImpl::new(stmt) };
-        let remote_schema = Arc::new(build_remote_schema(cursor)?);
+        let remote_schema = Arc::new(build_remote_schema(&mut prepared)?);
         Ok(remote_schema)
     }
 

--- a/remote-table/src/connection/mdb/schema.rs
+++ b/remote-table/src/connection/mdb/schema.rs
@@ -4,10 +4,9 @@ use crate::RemoteField;
 use crate::RemoteSchema;
 use crate::RemoteType;
 use datafusion_common::DataFusionError;
-use odbc_api::CursorImpl;
+use odbc_api::Prepared;
 use odbc_api::ResultSetMetadata;
-use odbc_api::handles::{AsStatementRef, StatementImpl};
-use odbc_api::handles::{ColumnDescription, Statement};
+use odbc_api::handles::{AsStatementRef, ColumnDescription, Statement, StatementImpl};
 
 /// Lossy decode of an ODBC column name. `ColumnDescription.name` is
 /// `Vec<SqlChar>` where `SqlChar` is `u8` on non-Windows (odbc-api default)
@@ -27,8 +26,10 @@ fn sql_chars_to_string_lossy(name: &[u16]) -> String {
     String::from_utf16_lossy(name)
 }
 
-pub(super) fn build_remote_schema(mut cursor: CursorImpl<StatementImpl>) -> DFResult<RemoteSchema> {
-    let col_count = cursor
+pub(super) fn build_remote_schema(
+    prepared: &mut Prepared<StatementImpl<'_>>,
+) -> DFResult<RemoteSchema> {
+    let col_count = prepared
         .num_result_cols()
         .map_err(|e| DataFusionError::External(Box::new(e)))? as u16;
     let mut remote_fields = vec![];
@@ -38,7 +39,7 @@ pub(super) fn build_remote_schema(mut cursor: CursorImpl<StatementImpl>) -> DFRe
         // col_nullability return NoDiagnostics), so we go through the
         // low-level SQLDescribeCol path.
         let mut col_desc = ColumnDescription::default();
-        let describe_result = cursor.as_stmt_ref().describe_col(i, &mut col_desc);
+        let describe_result = prepared.as_stmt_ref().describe_col(i, &mut col_desc);
         if describe_result.is_err() {
             return Err(DataFusionError::Plan(format!(
                 "describe_col failed for column {i} on mdb"


### PR DESCRIPTION
## Summary
Replace the manual unsafe ODBC statement lifecycle in `MdbConnection::infer_schema` with odbc-api's safe `Connection::prepare()` API.

## Before
```rust
let pre = conn.preallocate()?;
let mut stmt = pre.into_handle();
let sql_text = SqlText::new(&sql);
stmt.prepare(&sql_text)?;
unsafe { stmt.execute() }?;
let cursor = unsafe { CursorImpl::new(stmt) };
let remote_schema = Arc::new(build_remote_schema(cursor)?);
```

## After
```rust
let mut prepared = conn.prepare(&sql)?;
let remote_schema = Arc::new(build_remote_schema(&mut prepared)?);
```

`Prepared` implements `ResultSetMetadata` and `AsStatementRef`, so column metadata is available directly after prepare — no execute or cursor needed.