### PR TITLE
chore: add chrono-tz feature to arrow dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.dependencies]
 datafusion = "53"
 datafusion-proto = "53"
-arrow = "58"
+arrow = { version = "58", features = ["chrono-tz"] }
 datafusion-common = "53"
 datafusion-execution = "53"
 datafusion-expr = "53"


### PR DESCRIPTION
Enable chrono-tz feature for arrow to support timezone-aware timestamp operations.