### PR TITLE
test: expand gaussdb integration coverage

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -122,6 +122,38 @@ pub async fn setup_gaussdb_db() {
         compose
     });
     wait_container_ready(RemoteDbType::GaussDB).await;
+    wait_gaussdb_init_done().await;
+}
+
+/// openGauss accepts connections while the init scripts are still running, so
+/// `select 1` is not enough to know that the test tables exist yet. Wait until
+/// the last table created by `opengauss_init.sql` is visible.
+async fn wait_gaussdb_init_done() {
+    let conn = utils::build_conn_options(RemoteDbType::GaussDB);
+    let mut retry = 0;
+    loop {
+        match datafusion_remote_table::RemoteTable::try_new(
+            conn.clone(),
+            vec!["unconstrained_numeric"],
+        )
+        .await
+        {
+            Ok(table)
+                if table
+                    .remote_schema()
+                    .is_some_and(|schema| !schema.fields.is_empty()) =>
+            {
+                break;
+            }
+            Ok(_) => eprintln!("gaussdb init not done: test tables not created yet"),
+            Err(err) => eprintln!("gaussdb init check error: {err:?}"),
+        }
+        retry += 1;
+        if retry > 60 {
+            panic!("gaussdb test tables are still not available after 300 seconds");
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    }
 }
 
 static DM_DB: OnceLock<DockerCompose> = OnceLock::new();

--- a/integration-tests/testdata/gaussdb/opengauss_init.sql
+++ b/integration-tests/testdata/gaussdb/opengauss_init.sql
@@ -29,7 +29,9 @@ CREATE TABLE supported_data_types (
     real_array_col REAL[],
     double_array_col DOUBLE PRECISION[],
 
+    char_array_col CHAR(10)[],
     varchar_array_col VARCHAR(255)[],
+    bpchar_array_col BPCHAR[],
     text_array_col TEXT[],
 
     bool_array_col BOOLEAN[],
@@ -38,8 +40,8 @@ CREATE TABLE supported_data_types (
 );
 
 INSERT INTO supported_data_types VALUES
-(1, 2, 3, 1.1, 2.2, 3.3, 'char', 'varchar', 'bpchar', 'text', E'\\xDEADBEEF', '2023-10-01', '12:34:56', '3 months 2 weeks', TRUE, '{"key1": "value1"}', '{"key2": "value2"}', ARRAY[1, 2], ARRAY[3, 4], ARRAY[5, 6], ARRAY[1.1, 2.2], ARRAY[3.3, 4.4], ARRAY['varchar0', 'varchar1'], ARRAY['text0', 'text1'], ARRAY[true, false], 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
-(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+(1, 2, 3, 1.1, 2.2, 3.3, 'char', 'varchar', 'bpchar', 'text', E'\\xDEADBEEF', '2023-10-01', '12:34:56', '3 months 2 weeks', TRUE, '{"key1": "value1"}', '{"key2": "value2"}', ARRAY[1, 2], ARRAY[3, 4], ARRAY[5, 6], ARRAY[1.1, 2.2], ARRAY[3.3, 4.4], ARRAY['char0', 'char1'], ARRAY['varchar0', 'varchar1'], ARRAY['bpchar0', 'bpchar1'], ARRAY['text0', 'text1'], ARRAY[true, false], 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
+(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 
 CREATE TABLE simple_table (
@@ -81,12 +83,20 @@ CREATE TABLE insert_supported_data_types (
     real_array_col REAL[],
     double_array_col DOUBLE PRECISION[],
 
+    char_array_col CHAR(10)[],
     varchar_array_col VARCHAR(255)[],
+    bpchar_array_col BPCHAR[],
     text_array_col TEXT[],
 
     bool_array_col BOOLEAN[],
 
     uuid_col UUID
+);
+
+
+CREATE TABLE insert_table_with_primary_key (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255)
 );
 
 
@@ -106,5 +116,12 @@ INSERT INTO timestamp_test VALUES
 ('0001-01-01 00:00:00', '0001-01-01 00:00:00+00', '0001-01-01 00:00:00', '0001-01-01 00:00:00.000', '0001-01-01 00:00:00.000000'),
 ('9999-12-31 23:59:59', '9999-12-31 23:59:59+00', '9999-12-31 23:59:59', '9999-12-31 23:59:59.999', '9999-12-31 23:59:59.999999'),
 (NULL, NULL, NULL, NULL, NULL);
+
+
+CREATE TABLE unconstrained_numeric (
+    numeric_col NUMERIC
+);
+
+INSERT INTO unconstrained_numeric VALUES (1.1), (12.12), (123.123), (12345678901.12345678901), (123456789012345678901234567890.1234567890123456789);
 
 GRANT ALL ON ALL TABLES IN SCHEMA public TO gaussdb;

--- a/integration-tests/tests/gaussdb.rs
+++ b/integration-tests/tests/gaussdb.rs
@@ -1,9 +1,18 @@
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::arrow::util::pretty::pretty_format_batches;
-use datafusion::prelude::SessionContext;
-use datafusion_remote_table::{RemoteDbType, RemoteSource, RemoteTable};
+use datafusion::physical_plan::collect;
+use datafusion::physical_plan::display::DisplayableExecutionPlan;
+use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion_remote_table::{
+    ConnectionOptions, GaussDBType, RemoteDbType, RemoteField, RemoteSchema, RemoteSource,
+    RemoteTable, RemoteType,
+};
 use integration_tests::setup_gaussdb_db;
-use integration_tests::utils::{assert_plan_and_result, assert_sqls, build_conn_options};
+use integration_tests::utils::{
+    assert_plan_and_result, assert_result, assert_sqls, build_conn_options,
+};
 use std::sync::Arc;
+use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread")]
 pub async fn gaussdb_simple_query() {
@@ -35,36 +44,137 @@ pub async fn gaussdb_simple_query() {
 #[tokio::test(flavor = "multi_thread")]
 pub async fn supported_gaussdb_types() {
     setup_gaussdb_db().await;
+    assert_result(
+        RemoteDbType::GaussDB,
+        "SELECT * FROM supported_data_types",
+        "SELECT * FROM remote_table",
+        r#"+--------------+-------------+------------+----------+------------+--------------+------------+-------------+------------+----------+-----------+---------------------+----------+----------------+-------------+-------------------+-------------------+--------------------+-------------------+------------------+----------------+------------------+--------------------------+----------------------+--------------------+----------------+----------------+----------------------------------+
+| smallint_col | integer_col | bigint_col | real_col | double_col | numeric_col  | char_col   | varchar_col | bpchar_col | text_col | bytea_col | date_col            | time_col | interval_col   | boolean_col | json_col          | jsonb_col         | smallint_array_col | integer_array_col | bigint_array_col | real_array_col | double_array_col | char_array_col           | varchar_array_col    | bpchar_array_col   | text_array_col | bool_array_col | uuid_col                         |
++--------------+-------------+------------+----------+------------+--------------+------------+-------------+------------+----------+-----------+---------------------+----------+----------------+-------------+-------------------+-------------------+--------------------+-------------------+------------------+----------------+------------------+--------------------------+----------------------+--------------------+----------------+----------------+----------------------------------+
+| 1            | 2           | 3          | 1.1      | 2.2        | 3.3000000000 | char       | varchar     | bpchar     | text     | deadbeef  | 2023-10-01T00:00:00 | 12:34:56 | 3 mons 14 days | true        | {"key1":"value1"} | {"key2":"value2"} | [1, 2]             | [3, 4]            | [5, 6]           | [1.1, 2.2]     | [3.3, 4.4]       | [char0     , char1     ] | [varchar0, varchar1] | [bpchar0, bpchar1] | [text0, text1] | [true, false]  | a0eebc999c0b4ef8bb6d6bb9bd380a11 |
+|              |             |            |          |            |              |            |             |            |          |           |                     |          |                |             |                   |                   |                    |                   |                  |                |                  |                          |                      |                    |                |                |                                  |
++--------------+-------------+------------+----------+------------+--------------+------------+-------------+------------+----------+-----------+---------------------+----------+----------------+-------------+-------------------+-------------------+--------------------+-------------------+------------------+----------------+------------------+--------------------------+----------------------+--------------------+----------------+----------------+----------------------------------+"#,
+    )
+    .await;
+
+    assert_result(
+        RemoteDbType::GaussDB,
+        vec!["supported_data_types"],
+        "SELECT * FROM remote_table",
+        r#"+--------------+-------------+------------+----------+------------+-------------+------------+-------------+------------+----------+-----------+---------------------+----------+----------------+-------------+-------------------+-------------------+--------------------+-------------------+------------------+----------------+------------------+--------------------------+----------------------+--------------------+----------------+----------------+----------------------------------+
+| smallint_col | integer_col | bigint_col | real_col | double_col | numeric_col | char_col   | varchar_col | bpchar_col | text_col | bytea_col | date_col            | time_col | interval_col   | boolean_col | json_col          | jsonb_col         | smallint_array_col | integer_array_col | bigint_array_col | real_array_col | double_array_col | char_array_col           | varchar_array_col    | bpchar_array_col   | text_array_col | bool_array_col | uuid_col                         |
++--------------+-------------+------------+----------+------------+-------------+------------+-------------+------------+----------+-----------+---------------------+----------+----------------+-------------+-------------------+-------------------+--------------------+-------------------+------------------+----------------+------------------+--------------------------+----------------------+--------------------+----------------+----------------+----------------------------------+
+| 1            | 2           | 3          | 1.1      | 2.2        | 3.30        | char       | varchar     | bpchar     | text     | deadbeef  | 2023-10-01T00:00:00 | 12:34:56 | 3 mons 14 days | true        | {"key1":"value1"} | {"key2":"value2"} | [1, 2]             | [3, 4]            | [5, 6]           | [1.1, 2.2]     | [3.3, 4.4]       | [char0     , char1     ] | [varchar0, varchar1] | [bpchar0, bpchar1] | [text0, text1] | [true, false]  | a0eebc999c0b4ef8bb6d6bb9bd380a11 |
+|              |             |            |          |            |             |            |             |            |          |           |                     |          |                |             |                   |                   |                    |                   |                  |                |                  |                          |                      |                    |                |                |                                  |
++--------------+-------------+------------+----------+------------+-------------+------------+-------------+------------+----------+-----------+---------------------+----------+----------------+-------------+-------------------+-------------------+--------------------+-------------------+------------------+----------------+------------------+--------------------------+----------------------+--------------------+----------------+----------------+----------------------------------+"#,
+    )
+    .await;
+}
+
+#[rstest::rstest]
+#[case("SELECT * FROM timestamp_test".into())]
+#[case(vec!["timestamp_test"].into())]
+#[tokio::test(flavor = "multi_thread")]
+pub async fn supported_gaussdb_timestamp_type(#[case] source: RemoteSource) {
+    setup_gaussdb_db().await;
+    assert_result(
+        RemoteDbType::GaussDB,
+        source,
+        "SELECT * FROM remote_table",
+        r#"+----------------------------+-----------------------------+---------------------+-------------------------+----------------------------+
+| timestamp_col              | timestamptz_col             | timestamp_0         | timestamp_3             | timestamp_6                |
++----------------------------+-----------------------------+---------------------+-------------------------+----------------------------+
+| 2023-10-27T12:34:56        | 2023-10-27T10:34:56Z        | 2023-10-27T12:34:56 | 2023-10-27T12:34:56.123 | 2023-10-27T12:34:56.123456 |
+| 1969-07-20T20:17:40        | 1969-07-20T20:17:40Z        | 1969-07-20T20:17:40 | 1969-07-20T20:17:40.123 | 1969-07-20T20:17:40.123456 |
+| 2030-12-31T23:59:59        | 2030-12-31T23:59:59Z        | 2030-12-31T23:59:59 | 2030-12-31T23:59:59.999 | 2030-12-31T23:59:59.999999 |
+| 2023-10-27T12:34:56.876543 | 2023-10-27T12:34:56.876543Z | 2023-10-27T12:34:57 | 2023-10-27T12:34:56.877 | 2023-10-27T12:34:56.876543 |
+| 0001-01-01T00:00:00        | 0001-01-01T00:00:00Z        | 0001-01-01T00:00:00 | 0001-01-01T00:00:00     | 0001-01-01T00:00:00        |
+| 9999-12-31T23:59:59        | 9999-12-31T23:59:59Z        | 9999-12-31T23:59:59 | 9999-12-31T23:59:59.999 | 9999-12-31T23:59:59.999999 |
+|                            |                             |                     |                         |                            |
++----------------------------+-----------------------------+---------------------+-------------------------+----------------------------+"#,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn table_columns() {
+    setup_gaussdb_db().await;
+    let sql = format!(
+        r#"
+        SELECT
+    a.attname AS column_name,
+    pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,
+    CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END AS is_nullable,
+    t.typname AS udt_name
+FROM
+    pg_catalog.pg_attribute a
+JOIN
+    pg_catalog.pg_class c ON a.attrelid = c.oid
+JOIN
+    pg_catalog.pg_type t ON a.atttypid = t.oid
+WHERE
+    c.relname = '{}'
+    AND c.relkind IN ('r', 'v', 'm')
+    AND a.attnum > 0
+    AND NOT a.attisdropped
+ORDER BY
+    a.attnum
+        "#,
+        "simple_table"
+    );
+    assert_result(
+        RemoteDbType::GaussDB,
+        &sql,
+        "SELECT * FROM remote_table",
+        r#"+-------------+------------------------+-------------+----------+
+| column_name | data_type              | is_nullable | udt_name |
++-------------+------------------------+-------------+----------+
+| id          | integer                | NO          | int4     |
+| name        | character varying(255) | NO          | varchar  |
++-------------+------------------------+-------------+----------+"#,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn various_sqls() {
+    setup_gaussdb_db().await;
 
     assert_sqls(
         RemoteDbType::GaussDB,
         vec![
-            RemoteSource::Table(vec![
-                "public".to_string(),
-                "supported_data_types".to_string(),
-            ]),
-            RemoteSource::Query("SELECT * FROM supported_data_types".to_string()),
+            "select * from pg_catalog.pg_stat_all_tables".into(),
+            vec!["pg_catalog", "pg_stat_all_tables"].into(),
         ],
     )
     .await;
 }
 
+#[rstest::rstest]
+#[case("SELECT * from simple_table".into())]
+#[case(vec!["simple_table"].into())]
 #[tokio::test(flavor = "multi_thread")]
-pub async fn supported_gaussdb_timestamp_type() {
+async fn pushdown_limit(#[case] source: RemoteSource) {
     setup_gaussdb_db().await;
-
-    assert_sqls(
+    assert_plan_and_result(
         RemoteDbType::GaussDB,
-        vec![RemoteSource::Table(vec![
-            "public".to_string(),
-            "timestamp_test".to_string(),
-        ])],
+        source,
+        "select * from remote_table limit 1",
+        vec![
+            "CooperativeExec\n  RemoteTableScanExec: source=query, limit=1\n",
+            "CooperativeExec\n  RemoteTableScanExec: source=simple_table, limit=1\n",
+        ],
+        r#"+----+------+
+| id | name |
++----+------+
+| 1  | Tom  |
++----+------+"#,
     )
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
-pub async fn pushdown_limit() {
+pub async fn pushdown_limit_order_by() {
     setup_gaussdb_db().await;
 
     assert_plan_and_result(
@@ -87,82 +197,296 @@ pub async fn pushdown_limit() {
     .await;
 }
 
+#[rstest::rstest]
+#[case("SELECT * from simple_table".into())]
+#[case(vec!["simple_table"].into())]
 #[tokio::test(flavor = "multi_thread")]
-pub async fn pushdown_filters() {
+async fn pushdown_filters(#[case] source: RemoteSource) {
     setup_gaussdb_db().await;
+    assert_plan_and_result(
+        RemoteDbType::GaussDB,
+        source,
+        "select * from remote_table where id = 1",
+        vec![
+            "CooperativeExec\n  RemoteTableScanExec: source=query, filters=[(\"id\" = 1)]\n",
+            "CooperativeExec\n  RemoteTableScanExec: source=simple_table, filters=[(\"id\" = 1)]\n",
+        ],
+        r#"+----+------+
+| id | name |
++----+------+
+| 1  | Tom  |
++----+------+"#,
+    )
+    .await;
+}
+
+#[rstest::rstest]
+#[case("SELECT * from simple_table".into())]
+#[case(vec!["simple_table"].into())]
+#[tokio::test(flavor = "multi_thread")]
+async fn count1_agg(#[case] source: RemoteSource) {
+    setup_gaussdb_db().await;
+    assert_plan_and_result(
+        RemoteDbType::GaussDB,
+        source.clone(),
+        "select count(*) from remote_table",
+        vec!["ProjectionExec: expr=[3 as count(*)]\n  PlaceholderRowExec\n"],
+        r#"+----------+
+| count(*) |
++----------+
+| 3        |
++----------+"#,
+    )
+    .await;
 
     assert_plan_and_result(
         RemoteDbType::GaussDB,
-        RemoteSource::Table(vec!["public".to_string(), "simple_table".to_string()]),
-        "SELECT id, name FROM remote_table WHERE id > 1",
-        vec![
-            r#"CooperativeExec
-  RemoteTableScanExec: source=public.simple_table, filters=[("id" > 1)]
-"#,
-        ],
-        r#"+----+-------+
-| id | name  |
-+----+-------+
-| 2  | Jerry |
-| 3  | Spike |
-+----+-------+"#,
+        source.clone(),
+        "select count(*) from remote_table where id > 1",
+        vec!["ProjectionExec: expr=[2 as count(*)]\n  PlaceholderRowExec\n"],
+        r#"+----------+
+| count(*) |
++----------+
+| 2        |
++----------+"#,
+    )
+    .await;
+
+    assert_plan_and_result(
+        RemoteDbType::GaussDB,
+        source.clone(),
+        "select count(*) from (select * from remote_table where id > 1 limit 1)",
+        vec!["ProjectionExec: expr=[1 as count(*)]\n  PlaceholderRowExec\n"],
+        r#"+----------+
+| count(*) |
++----------+
+| 1        |
++----------+"#,
+    )
+    .await;
+}
+
+#[rstest::rstest]
+#[case("SELECT * from supported_data_types".into())]
+#[case(vec!["supported_data_types"].into())]
+#[tokio::test(flavor = "multi_thread")]
+pub async fn table_projection(#[case] source: RemoteSource) {
+    setup_gaussdb_db().await;
+    assert_result(
+        RemoteDbType::GaussDB,
+        source,
+        "SELECT integer_col, varchar_col FROM remote_table",
+        r#"+-------------+-------------+
+| integer_col | varchar_col |
++-------------+-------------+
+| 2           | varchar     |
+|             |             |
++-------------+-------------+"#,
     )
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
-pub async fn table_projection() {
-    setup_gaussdb_db().await;
-
-    assert_plan_and_result(
-        RemoteDbType::GaussDB,
-        RemoteSource::Table(vec!["public".to_string(), "simple_table".to_string()]),
-        "SELECT name FROM remote_table",
-        vec![
-            r#"CooperativeExec
-  RemoteTableScanExec: source=public.simple_table, projection=[name]
-"#,
-        ],
-        r#"+-------+
-| name  |
-+-------+
-| Tom   |
-| Jerry |
-| Spike |
-+-------+"#,
-    )
-    .await;
-}
-
-#[tokio::test(flavor = "multi_thread")]
-pub async fn empty_projection() {
+async fn empty_projection() {
     setup_gaussdb_db().await;
 
     let options = build_conn_options(RemoteDbType::GaussDB);
-    let table = RemoteTable::try_new(
+    let table = RemoteTable::try_new(options, "select * from simple_table")
+        .await
+        .unwrap();
+
+    let config = SessionConfig::new().with_target_partitions(12);
+    let ctx = SessionContext::new_with_config(config);
+
+    let df = ctx.read_table(Arc::new(table)).unwrap();
+    let df = df.select_columns(&[]).unwrap();
+
+    let exec_plan = df.create_physical_plan().await.unwrap();
+    let plan_display = DisplayableExecutionPlan::new(exec_plan.as_ref())
+        .indent(true)
+        .to_string();
+    println!("{plan_display}");
+    assert_eq!(
+        plan_display,
+        "CooperativeExec\n  RemoteTableScanExec: source=query, projection=[]\n"
+    );
+
+    let result = collect(exec_plan, ctx.task_ctx()).await.unwrap();
+    assert_eq!(result.len(), 1);
+    let batch = &result[0];
+    assert_eq!(batch.num_columns(), 0);
+    assert_eq!(batch.num_rows(), 3);
+}
+
+#[rstest::rstest]
+#[case("SELECT * FROM unconstrained_numeric".into())]
+#[case(vec!["unconstrained_numeric"].into())]
+#[tokio::test(flavor = "multi_thread")]
+pub async fn unconstrained_numeric(#[case] source: RemoteSource) {
+    setup_gaussdb_db().await;
+
+    assert_result(
+        RemoteDbType::GaussDB,
+        source.clone(),
+        "SELECT * FROM remote_table",
+        r#"+-------------------------------------------+
+| numeric_col                               |
++-------------------------------------------+
+| 1.1000000000                              |
+| 12.1200000000                             |
+| 123.1230000000                            |
+| 12345678901.1234567890                    |
+| 123456789012345678901234567890.1234567890 |
++-------------------------------------------+"#,
+    )
+    .await;
+
+    let options = build_conn_options(RemoteDbType::GaussDB);
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "numeric_col",
+        DataType::Decimal128(38, 5),
+        true,
+    )]));
+    let table = RemoteTable::try_new_with_schema(options, source, schema)
+        .await
+        .unwrap();
+
+    let ctx = SessionContext::new();
+    ctx.register_table("remote_table", Arc::new(table)).unwrap();
+    let df = ctx.sql("SELECT * FROM remote_table").await.unwrap();
+    let batches = df.collect().await.unwrap();
+    let table_str = pretty_format_batches(&batches).unwrap().to_string();
+    println!("{}", table_str);
+    assert_eq!(
+        table_str,
+        r#"+--------------------------------------+
+| numeric_col                          |
++--------------------------------------+
+| 1.10000                              |
+| 12.12000                             |
+| 123.12300                            |
+| 12345678901.12345                    |
+| 123456789012345678901234567890.12345 |
++--------------------------------------+"#,
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn insert_supported_gaussdb_types() {
+    setup_gaussdb_db().await;
+    assert_result(RemoteDbType::GaussDB, vec!["insert_supported_data_types"],
+    "insert into remote_table values
+        (1, 2, 3, 1.1, 2.2, 3.3, 'char', 'varchar', 'bpchar', 'text', X'01', '2023-10-01', '12:34:56', '2023-10-01 12:34:56', '2023-10-01 12:34:56+00', '3 months 2 weeks', true, '{\"key1\":\"value1\"}', '{\"key2\":\"value2\"}', [1, 2], [3, 4], [5, 6], [1.1, 2.2], [3.3, 4.4], ['char0', 'char1'], ['varchar0', 'varchar1'], ['bpchar0', 'bpchar1'], ['text0', 'text1'], [true, false], X'a0eebc999c0b4ef8bb6d6bb9bd380a11'),
+        (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)",
+        r#"+-------+
+| count |
++-------+
+| 2     |
++-------+"#,
+).await;
+
+    assert_result(RemoteDbType::GaussDB, vec!["insert_supported_data_types"], "SELECT * FROM remote_table",
+    r#"+--------------+-------------+------------+----------+------------+-------------+------------+-------------+------------+----------+-----------+---------------------+----------+---------------------+----------------------+----------------+-------------+-------------------+-------------------+--------------------+-------------------+------------------+----------------+------------------+--------------------------+----------------------+--------------------+----------------+----------------+----------------------------------+
+| smallint_col | integer_col | bigint_col | real_col | double_col | numeric_col | char_col   | varchar_col | bpchar_col | text_col | bytea_col | date_col            | time_col | timestamp_col       | timestamptz_col      | interval_col   | boolean_col | json_col          | jsonb_col         | smallint_array_col | integer_array_col | bigint_array_col | real_array_col | double_array_col | char_array_col           | varchar_array_col    | bpchar_array_col   | text_array_col | bool_array_col | uuid_col                         |
++--------------+-------------+------------+----------+------------+-------------+------------+-------------+------------+----------+-----------+---------------------+----------+---------------------+----------------------+----------------+-------------+-------------------+-------------------+--------------------+-------------------+------------------+----------------+------------------+--------------------------+----------------------+--------------------+----------------+----------------+----------------------------------+
+| 1            | 2           | 3          | 1.1      | 2.2        | 3.30        | char       | varchar     | bpchar     | text     | 01        | 2023-10-01T00:00:00 | 12:34:56 | 2023-10-01T12:34:56 | 2023-10-01T12:34:56Z | 3 mons 14 days | true        | {"key1":"value1"} | {"key2":"value2"} | [1, 2]             | [3, 4]            | [5, 6]           | [1.1, 2.2]     | [3.3, 4.4]       | [char0     , char1     ] | [varchar0, varchar1] | [bpchar0, bpchar1] | [text0, text1] | [true, false]  | a0eebc999c0b4ef8bb6d6bb9bd380a11 |
+|              |             |            |          |            |             |            |             |            |          |           |                     |          |                     |                      |                |             |                   |                   |                    |                   |                  |                |                  |                          |                      |                    |                |                |                                  |
++--------------+-------------+------------+----------+------------+-------------+------------+-------------+------------+----------+-----------+---------------------+----------+---------------------+----------------------+----------------+-------------+-------------------+-------------------+--------------------+-------------------+------------------+----------------+------------------+--------------------------+----------------------+--------------------+----------------+----------------+----------------------------------+"#,
+    ).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn insert_table_with_primary_key() {
+    setup_gaussdb_db().await;
+
+    let options = build_conn_options(RemoteDbType::GaussDB);
+    let remote_schema = Arc::new(RemoteSchema::new(vec![
+        RemoteField::new("id", RemoteType::GaussDB(GaussDBType::Int4), false)
+            .with_auto_increment(true),
+        RemoteField::new("name", RemoteType::GaussDB(GaussDBType::Varchar), true),
+    ]));
+    let table = RemoteTable::try_new_with_remote_schema(
         options,
-        RemoteSource::Table(vec!["public".to_string(), "simple_table".to_string()]),
+        vec!["insert_table_with_primary_key"],
+        remote_schema,
     )
     .await
     .unwrap();
+    println!("remote schema: {:#?}", table.remote_schema());
 
     let ctx = SessionContext::new();
     ctx.register_table("remote_table", Arc::new(table)).unwrap();
 
-    let result = ctx
-        .sql("SELECT count(1) FROM remote_table")
-        .await
-        .unwrap()
-        .collect()
+    let df = ctx
+        .sql("insert into remote_table (name) values ('John')")
         .await
         .unwrap();
-    let expected = r#"+-----------------+
-| count(Int64(1)) |
-+-----------------+
-| 3               |
-+-----------------+"#;
+    let exec_plan = df.create_physical_plan().await.unwrap();
+    println!(
+        "{}",
+        DisplayableExecutionPlan::new(exec_plan.as_ref()).indent(true)
+    );
+
+    let result = collect(exec_plan, ctx.task_ctx()).await.unwrap();
+    println!("{}", pretty_format_batches(&result).unwrap());
+
     assert_eq!(
         pretty_format_batches(&result).unwrap().to_string(),
-        expected
+        r#"+-------+
+| count |
++-------+
+| 1     |
++-------+"#,
     );
+
+    assert_result(
+        RemoteDbType::GaussDB,
+        vec!["insert_table_with_primary_key"],
+        "SELECT * FROM remote_table",
+        r#"+----+------+
+| id | name |
++----+------+
+| 1  | John |
++----+------+"#,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn disable_pooled_connections() {
+    setup_gaussdb_db().await;
+
+    let options = build_conn_options(RemoteDbType::GaussDB);
+    let ConnectionOptions::GaussDB(options) = options else {
+        unreachable!()
+    };
+    let options = options
+        .with_pool_max_size(100)
+        .with_pool_min_idle(0)
+        .with_pool_idle_timeout(Duration::from_micros(1))
+        .with_pool_ttl_check_interval(Duration::from_secs(3));
+    let table = RemoteTable::try_new(options, "select * from simple_table")
+        .await
+        .unwrap();
+    let pool = table.pool().await.unwrap().clone();
+    let ctx = SessionContext::new();
+    ctx.register_table("remote_table", Arc::new(table)).unwrap();
+
+    let mut handles = Vec::new();
+    for _ in 0..50 {
+        let ctx = ctx.clone();
+        let handle = tokio::spawn(async move {
+            let df = ctx.sql("select * from remote_table").await.unwrap();
+            let _batches = df.collect().await.unwrap();
+        });
+        handles.push(handle);
+    }
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    let pool_state = pool.state().await.unwrap();
+    assert_eq!(pool_state.connections, 0);
+    assert_eq!(pool_state.idle_connections, 0);
 }

--- a/remote-table/src/connection/gaussdb.rs
+++ b/remote-table/src/connection/gaussdb.rs
@@ -14,7 +14,8 @@ use arrow::array::{
     TimestampNanosecondBuilder, UInt32Builder, make_builder,
 };
 use arrow::datatypes::{
-    DataType, Date32Type, IntervalMonthDayNanoType, IntervalUnit, SchemaRef, TimeUnit,
+    DECIMAL256_MAX_PRECISION, DataType, Date32Type, IntervalMonthDayNanoType, IntervalUnit,
+    SchemaRef, TimeUnit,
 };
 use bb8_gaussdb::GaussDBConnectionManager;
 use bb8_gaussdb::tokio_gaussdb::types::{FromSql, Type};
@@ -152,37 +153,69 @@ macro_rules! handle_primitive_array_type {
 
 struct BigDecimalFromSql(BigDecimal);
 
+#[allow(clippy::cast_sign_loss)]
+#[allow(clippy::cast_possible_wrap)]
+#[allow(clippy::cast_possible_truncation)]
 impl<'a> FromSql<'a> for BigDecimalFromSql {
     fn from_sql(
         _ty: &Type,
         raw: &'a [u8],
     ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
-        // Numeric is stored as digits in base 10000
+        // Numeric is stored as digits in base 10000, preceded by the digit
+        // count, the weight of the first digit, the sign and the display scale.
         if raw.len() < 8 {
             return Err("numeric too short".into());
         }
-        let num_digits = u16::from_be_bytes([raw[0], raw[1]]);
-        let _weight = i16::from_be_bytes([raw[2], raw[3]]);
-        let sign = u16::from_be_bytes([raw[4], raw[5]]);
-        let dscale = u16::from_be_bytes([raw[6], raw[7]]);
+        let raw_u16: Vec<u16> = raw
+            .chunks(2)
+            .map(|chunk| {
+                if chunk.len() == 2 {
+                    u16::from_be_bytes([chunk[0], chunk[1]])
+                } else {
+                    u16::from_be_bytes([chunk[0], 0])
+                }
+            })
+            .collect();
 
-        let mut result = BigInt::from(0u8);
-        for i in 0..num_digits as usize {
-            let start = 8 + i * 2;
-            let digit = u16::from_be_bytes([raw[start], raw[start + 1]]);
-            result = result * 10000u16 + BigInt::from(digit);
+        let base_10_000_digit_count = raw_u16[0];
+        let weight = raw_u16[1] as i16;
+        let sign = raw_u16[2];
+        let scale = raw_u16[3];
+
+        let mut base_10_000_digits = Vec::new();
+        for i in 4..4 + base_10_000_digit_count {
+            base_10_000_digits.push(raw_u16[i as usize]);
         }
+
+        let mut u8_digits = Vec::new();
+        for &base_10_000_digit in base_10_000_digits.iter().rev() {
+            let mut base_10_000_digit = base_10_000_digit;
+            let mut temp_result = Vec::new();
+            while base_10_000_digit > 0 {
+                temp_result.push((base_10_000_digit % 10) as u8);
+                base_10_000_digit /= 10;
+            }
+            while temp_result.len() < 4 {
+                temp_result.push(0);
+            }
+            u8_digits.extend(temp_result);
+        }
+        u8_digits.reverse();
+
+        let value_scale = 4 * (i64::from(base_10_000_digit_count) - i64::from(weight) - 1);
+        let size = i64::try_from(u8_digits.len())? + i64::from(scale) - value_scale;
+        u8_digits.resize(size as usize, 0);
+
         let sign = match sign {
-            0x0000 => Sign::Plus,
             0x4000 => Sign::Minus,
+            0x0000 => Sign::Plus,
             _ => return Err("invalid numeric sign".into()),
         };
 
-        let big_decimal = BigDecimal::new(
-            BigInt::from_bytes_be(sign, &result.to_bytes_be().1),
-            dscale as i64,
-        );
-        Ok(BigDecimalFromSql(big_decimal))
+        let Some(digits) = BigInt::from_radix_be(sign, u8_digits.as_slice(), 10) else {
+            return Err("Failed to parse numeric value".into());
+        };
+        Ok(BigDecimalFromSql(BigDecimal::new(digits, i64::from(scale))))
     }
 
     fn accepts(ty: &Type) -> bool {
@@ -257,7 +290,7 @@ fn gdb_type_to_remote_type(data_type: &Type) -> DFResult<GaussDBType> {
         Type::INT8 => GaussDBType::Int8,
         Type::FLOAT4 => GaussDBType::Float4,
         Type::FLOAT8 => GaussDBType::Float8,
-        Type::NUMERIC | Type::NUMERIC_ARRAY => GaussDBType::Numeric(38, 10),
+        Type::NUMERIC | Type::NUMERIC_ARRAY => GaussDBType::Numeric(DECIMAL256_MAX_PRECISION, 10),
         Type::OID => GaussDBType::Oid,
         Type::NAME => GaussDBType::Name,
         Type::VARCHAR => GaussDBType::Varchar,
@@ -304,7 +337,7 @@ fn parse_gdb_type(
         "real" | "float4" => Ok(GaussDBType::Float4),
         "double precision" | "float8" => Ok(GaussDBType::Float8),
         "numeric" => Ok(GaussDBType::Numeric(
-            numeric_precision.unwrap_or(38),
+            numeric_precision.unwrap_or(DECIMAL256_MAX_PRECISION),
             numeric_scale.unwrap_or(10),
         )),
         "oid" => Ok(GaussDBType::Oid),
@@ -620,8 +653,8 @@ fn rows_to_batch(
                         UInt32Builder,
                         row,
                         idx,
-                        i32,
-                        |v: i32| { Ok::<u32, DataFusionError>(v as u32) }
+                        u32,
+                        just_return
                     );
                 }
                 DataType::Int64 => {
@@ -657,7 +690,7 @@ fn rows_to_batch(
                         just_return
                     );
                 }
-                DataType::Decimal128(_precision, _scale) => {
+                DataType::Decimal128(_precision, scale) => {
                     let builder = builder
                         .as_any_mut()
                         .downcast_mut::<Decimal128Builder>()
@@ -672,7 +705,7 @@ fn rows_to_batch(
                     })?;
                     match v {
                         Some(bd) => {
-                            let i = big_decimal_to_i128(&bd.0, None)?;
+                            let i = big_decimal_to_i128(&bd.0, Some(*scale as i32))?;
                             builder.append_value(i);
                         }
                         None => builder.append_null(),

--- a/remote-table/src/literalize.rs
+++ b/remote-table/src/literalize.rs
@@ -1,5 +1,5 @@
 use crate::PostgresType;
-use crate::{DFResult, RemoteType};
+use crate::{DFResult, GaussDBType, RemoteType};
 use arrow::array::timezone::Tz;
 use arrow::array::*;
 use arrow::datatypes::*;
@@ -367,7 +367,7 @@ pub trait Literalize: Debug + Send + Sync + Any {
     ) -> DFResult<Vec<String>> {
         let db_type = remote_type.db_type();
         match remote_type {
-            RemoteType::Postgres(PostgresType::Uuid) => {
+            RemoteType::Postgres(PostgresType::Uuid) | RemoteType::GaussDB(GaussDBType::Uuid) => {
                 literalize_array!(array, |v| Ok::<_, DataFusionError>(format!(
                     "'{}'",
                     hex::encode(v)


### PR DESCRIPTION
## Summary

Ports the remaining Postgres integration tests to GaussDB and strengthens the existing ones so they assert real values instead of only checking that a query does not error. The GaussDB test target grows from 7 to 21 cases.

## Tests

- `supported_gaussdb_types`, `supported_gaussdb_timestamp_type`: assert exact values for both query and table sources.
- New: `table_columns`, `various_sqls`, `count1_agg`, `table_projection` (query + table), `pushdown_limit` (query + table), `pushdown_limit_order_by`, `pushdown_filters` (query + table), `empty_projection`, `unconstrained_numeric`, `insert_supported_gaussdb_types`, `insert_table_with_primary_key`, `disable_pooled_connections`.
- `opengauss_init.sql`: adds `char_array_col` / `bpchar_array_col`, `insert_table_with_primary_key` and `unconstrained_numeric`. Geometry and XML are omitted because this image has no PostGIS and is built without libxml.

## Backend fixes exposed by the stronger assertions

- Numeric decoding ignored the base-10000 weight, so `NUMERIC(10,2) = 3.30` read back as `330.00`. It now uses the same decoder as Postgres.
- `Decimal128` rows ignored the declared scale when scaling values.
- `OID` columns (e.g. `pg_stat_all_tables.relid`) could not be read: the `UInt32` branch now reads `u32`.
- UUID insert literals were emitted as bytea; they now use the quoted-hex form, like Postgres.
- Unconstrained `NUMERIC` now maps to `DECIMAL256_MAX_PRECISION`, matching Postgres.

## Test harness

`setup_gaussdb_db` now waits until the init tables exist. openGauss accepts connections while its init scripts are still running, so the previous `select 1` readiness check was not sufficient and the suite failed intermittently with "relation does not exist".

## Verification

- `cargo test -p integration-tests --test gaussdb` — 21 passed (run repeatedly on both `master` and the DataFusion 55 branch).
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test -p datafusion-remote-table`

Related: this overlaps with the older open PR #97, which is based on an earlier `master` and does not include the backend fixes.
