### PR TITLE
fix(mdb): correct filter pushdown and connections for .mdb sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
   - [x] Int2[] / Int4[] / Int8[]
   - [x] Float4[] / Float8[]
   - [x] Varchar[] / Text[] / Bool[]
+- [x] MDB (Microsoft Access, via the MDBTools ODBC driver)
+  - [x] Byte / Small Integer / Long Integer / Bit
+  - [x] Real / Double / Currency
+  - [x] Text / Memo / Binary / OLE / Guid
+  - [x] Date / Time / DateTime
 
 ## Thanks
 - [datafusion-table-providers](https://crates.io/crates/datafusion-table-providers)

--- a/integration-tests/tests/mdb.rs
+++ b/integration-tests/tests/mdb.rs
@@ -253,3 +253,121 @@ async fn list_tables_projection_and_limit() {
 +-------------------------------+"#
     );
 }
+
+#[rstest::rstest]
+#[case("SELECT * FROM Products WHERE UnitPrice > 20".into())]
+#[case(vec!["Products"].into())]
+#[tokio::test(flavor = "multi_thread")]
+async fn filter_on_currency_column(#[case] source: RemoteSource) {
+    // UnitPrice is a Jet Currency column. mdbtools' mdb_test_sarg() has no case
+    // for MONEY, so the pushed predicate filters nothing remotely; the filter is
+    // classified as inexact and DataFusion must apply it locally.
+    assert_plan_and_result(
+        RemoteDbType::Mdb,
+        source,
+        "select \"ProductID\", \"ProductName\", \"UnitPrice\" from remote_table \
+         where \"UnitPrice\" > 20 order by \"ProductID\" limit 6",
+        vec![
+            "SortPreservingMergeExec: [ProductID@0 ASC NULLS LAST], fetch=6\n  SortExec: TopK(fetch=6), expr=[ProductID@0 ASC NULLS LAST], preserve_partitioning=[true]\n    FilterExec: UnitPrice@2 > 20.0000\n      RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1\n        RemoteTableScanExec: source=query, projection=[ProductID, ProductName, UnitPrice]\n",
+            "SortPreservingMergeExec: [ProductID@0 ASC NULLS LAST], fetch=6\n  SortExec: TopK(fetch=6), expr=[ProductID@0 ASC NULLS LAST], preserve_partitioning=[true]\n    FilterExec: UnitPrice@2 > 20.0000\n      RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1\n        RemoteTableScanExec: source=Products, projection=[ProductID, ProductName, UnitPrice], filters=[(\"UnitPrice\" > 20.0000)]\n",
+        ],
+        r#"+-----------+---------------------------------+-----------+
+| ProductID | ProductName                     | UnitPrice |
++-----------+---------------------------------+-----------+
+| 4         | Chef Anton's Cajun Seasoning    | 22.0000   |
+| 5         | Chef Anton's Gumbo Mix          | 21.3500   |
+| 6         | Grandma's Boysenberry Spread    | 25.0000   |
+| 7         | Uncle Bob's Organic Dried Pears | 30.0000   |
+| 8         | Northwoods Cranberry Sauce      | 40.0000   |
+| 9         | Mishi Kobe Niku                 | 97.0000   |
++-----------+---------------------------------+-----------+"#,
+    )
+    .await;
+}
+
+#[rstest::rstest]
+#[case("SELECT * FROM Products WHERE UnitPrice > 20".into())]
+#[case(vec!["Products"].into())]
+#[tokio::test(flavor = "multi_thread")]
+async fn filter_on_currency_column_with_limit(#[case] source: RemoteSource) {
+    // The predicate cannot be evaluated by the driver, so the limit must not be
+    // pushed into the scan either: the scan would otherwise truncate the table
+    // before the local filter removes the non-matching rows.
+    assert_plan_and_result(
+        RemoteDbType::Mdb,
+        source,
+        "select \"ProductID\", \"UnitPrice\" from remote_table \
+         where \"UnitPrice\" > 20 order by \"ProductID\" limit 2",
+        vec![
+            "SortPreservingMergeExec: [ProductID@0 ASC NULLS LAST], fetch=2\n  SortExec: TopK(fetch=2), expr=[ProductID@0 ASC NULLS LAST], preserve_partitioning=[true]\n    FilterExec: UnitPrice@1 > 20.0000\n      RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1\n        RemoteTableScanExec: source=query, projection=[ProductID, UnitPrice]\n",
+            "SortPreservingMergeExec: [ProductID@0 ASC NULLS LAST], fetch=2\n  SortExec: TopK(fetch=2), expr=[ProductID@0 ASC NULLS LAST], preserve_partitioning=[true]\n    FilterExec: UnitPrice@1 > 20.0000\n      RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1\n        RemoteTableScanExec: source=Products, projection=[ProductID, UnitPrice], filters=[(\"UnitPrice\" > 20.0000)]\n",
+        ],
+        r#"+-----------+-----------+
+| ProductID | UnitPrice |
++-----------+-----------+
+| 4         | 22.0000   |
+| 5         | 21.3500   |
++-----------+-----------+"#,
+    )
+    .await;
+}
+
+#[rstest::rstest]
+#[case("SELECT * FROM Products WHERE ProductName LIKE 'Ch%'".into())]
+#[case(vec!["Products"].into())]
+#[tokio::test(flavor = "multi_thread")]
+async fn filter_on_text_column(#[case] source: RemoteSource) {
+    // Text comparisons are supported by mdb_test_sarg(), so the filter stays
+    // pushed down (no local FilterExec) and results are still correct.
+    assert_plan_and_result(
+        RemoteDbType::Mdb,
+        source,
+        "select \"ProductID\", \"ProductName\" from remote_table \
+         where \"ProductName\" like 'Ch%' order by \"ProductID\"",
+        vec![
+            "SortPreservingMergeExec: [ProductID@0 ASC NULLS LAST]\n  SortExec: expr=[ProductID@0 ASC NULLS LAST], preserve_partitioning=[true]\n    FilterExec: ProductName@1 LIKE Ch%\n      RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1\n        RemoteTableScanExec: source=query, projection=[ProductID, ProductName]\n",
+            "SortExec: expr=[ProductID@0 ASC NULLS LAST], preserve_partitioning=[false]\n  CooperativeExec\n    RemoteTableScanExec: source=Products, projection=[ProductID, ProductName], filters=[\"ProductName\" LIKE 'Ch%']\n",
+        ],
+        r#"+-----------+------------------------------+
+| ProductID | ProductName                  |
++-----------+------------------------------+
+| 1         | Chai                         |
+| 2         | Chang                        |
+| 4         | Chef Anton's Cajun Seasoning |
+| 5         | Chef Anton's Gumbo Mix       |
+| 39        | Chartreuse verte             |
+| 48        | Chocolade                    |
++-----------+------------------------------+"#,
+    )
+    .await;
+}
+
+#[rstest::rstest]
+#[case("SELECT * FROM Orders WHERE OrderID > 11070".into())]
+#[case(vec!["Orders"].into())]
+#[tokio::test(flavor = "multi_thread")]
+async fn filter_on_integer_column(#[case] source: RemoteSource) {
+    // Integer comparisons are supported by mdb_test_sarg().
+    assert_plan_and_result(
+        RemoteDbType::Mdb,
+        source,
+        "select \"OrderID\", \"CustomerID\", \"ShipVia\" from remote_table \
+         where \"OrderID\" > 11070 order by \"OrderID\"",
+        vec![
+            "SortPreservingMergeExec: [OrderID@0 ASC NULLS LAST]\n  SortExec: expr=[OrderID@0 ASC NULLS LAST], preserve_partitioning=[true]\n    FilterExec: OrderID@0 > 11070\n      RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1\n        RemoteTableScanExec: source=query, projection=[OrderID, CustomerID, ShipVia]\n",
+            "SortExec: expr=[OrderID@0 ASC NULLS LAST], preserve_partitioning=[false]\n  CooperativeExec\n    RemoteTableScanExec: source=Orders, projection=[OrderID, CustomerID, ShipVia], filters=[(\"OrderID\" > 11070)]\n",
+        ],
+        r#"+---------+------------+---------+
+| OrderID | CustomerID | ShipVia |
++---------+------------+---------+
+| 11071   | LILAS      | 1       |
+| 11072   | ERNSH      | 2       |
+| 11073   | PERIC      | 2       |
+| 11074   | SIMOB      | 2       |
+| 11075   | RICSU      | 2       |
+| 11076   | BONAP      | 2       |
+| 11077   | RATTC      | 2       |
++---------+------------+---------+"#,
+    )
+    .await;
+}

--- a/remote-table/src/connection/mdb/mod.rs
+++ b/remote-table/src/connection/mdb/mod.rs
@@ -144,18 +144,19 @@ impl Pool for MdbPool {
                 // exists). `CString` owns a NUL-terminated buffer, and `to_str`
                 // borrows exactly its length, so the driver stops at the
                 // terminator we own.
-                let connection_str = CString::new(self.options.connection_string()).map_err(|e| {
-                    DataFusionError::Execution(format!(
-                        "mdb connection string contains a NUL byte: {e}"
-                    ))
-                })?;
+                let connection_str =
+                    CString::new(self.options.connection_string()).map_err(|e| {
+                        DataFusionError::Execution(format!(
+                            "mdb connection string contains a NUL byte: {e}"
+                        ))
+                    })?;
                 let connection_str = connection_str
                     .to_str()
                     .expect("connection string built from a Rust String is valid UTF-8");
                 debug!("[remote-table] mdb connection string: {connection_str}");
                 let connection = env
                     .connect_with_connection_string(
-                        &connection_str,
+                        connection_str,
                         odbc_api::ConnectionOptions::default(),
                     )
                     .map_err(|e| {

--- a/remote-table/src/connection/mdb/mod.rs
+++ b/remote-table/src/connection/mdb/mod.rs
@@ -21,6 +21,7 @@ use log::debug;
 use odbc_api::Cursor;
 use odbc_api::Environment;
 use std::collections::HashMap;
+use std::ffi::CString;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -134,7 +135,23 @@ impl Pool for MdbPool {
             } else {
                 let env =
                     ODBC_ENV.get_or_init(|| Environment::new().expect("failed to create ODBC env"));
-                let connection_str = self.options.connection_string();
+                // libmdbodbc.so ignores the `cbConnStrIn` length passed to
+                // SQLDriverConnect and reads the connection string as a
+                // NUL-terminated C string, while odbc-api hands the driver the
+                // bytes of a Rust `&str`, which carry no terminator. The driver
+                // then reads into adjacent heap memory and appends whatever it
+                // finds to the DBQ path ("File not found" for a path that
+                // exists). `CString` owns a NUL-terminated buffer, and `to_str`
+                // borrows exactly its length, so the driver stops at the
+                // terminator we own.
+                let connection_str = CString::new(self.options.connection_string()).map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "mdb connection string contains a NUL byte: {e}"
+                    ))
+                })?;
+                let connection_str = connection_str
+                    .to_str()
+                    .expect("connection string built from a Rust String is valid UTF-8");
                 debug!("[remote-table] mdb connection string: {connection_str}");
                 let connection = env
                     .connect_with_connection_string(

--- a/remote-table/src/table.rs
+++ b/remote-table/src/table.rs
@@ -387,7 +387,9 @@ impl TableProvider for RemoteTable {
         }
 
         let remote_schema = if self.transform.is::<DefaultTransform>() {
-            Arc::new(RemoteSchema::empty())
+            self.remote_schema
+                .clone()
+                .unwrap_or_else(|| Arc::new(RemoteSchema::empty()))
         } else {
             let Some(remote_schema) = &self.remote_schema else {
                 return Err(DataFusionError::Plan(

--- a/remote-table/src/transform.rs
+++ b/remote-table/src/transform.rs
@@ -1,4 +1,4 @@
-use crate::{DFResult, RemoteDbType, RemoteSchemaRef};
+use crate::{DFResult, MdbType, RemoteDbType, RemoteSchemaRef, RemoteType};
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
 use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
@@ -42,6 +42,44 @@ impl dyn Transform {
     }
 }
 
+/// Whether a filter reads a column whose comparisons mdbtools does not evaluate.
+///
+/// `libmdbodbc.so` applies `WHERE` predicates through `mdb_test_sarg()`, which
+/// has no case for Money, Numeric, Binary, Complex or OLE columns: it prints
+/// "Calling mdb_test_sarg on unknown type" and leaves its result set to the
+/// initial "row matches" value. Pushing such a predicate as `Exact` would drop
+/// no rows remotely and DataFusion would not filter them locally either, so the
+/// predicate is reported as `Inexact` to keep a local `FilterExec` in the plan.
+fn mdb_filter_needs_local_evaluation(filter: &Expr, args: TransformArgs) -> bool {
+    if !matches!(args.db_type, RemoteDbType::Mdb) {
+        return false;
+    }
+
+    let mut needs_local_evaluation = false;
+    filter
+        .apply(|e| {
+            if let Expr::Column(column) = e
+                && let Some(field) = args
+                    .remote_schema
+                    .fields
+                    .iter()
+                    .find(|f| f.name == column.name)
+                && matches!(
+                    field.remote_type,
+                    RemoteType::Mdb(MdbType::Currency)
+                        | RemoteType::Mdb(MdbType::Binary(_))
+                        | RemoteType::Mdb(MdbType::OleObject)
+                )
+            {
+                needs_local_evaluation = true;
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })
+        .expect("won't fail");
+
+    needs_local_evaluation
+}
+
 #[derive(Debug)]
 pub struct DefaultTransform {}
 
@@ -72,6 +110,12 @@ impl Transform for DefaultTransform {
                 Ok(TreeNodeRecursion::Continue)
             })
             .expect("won't fail");
+
+        if pushdown == TableProviderFilterPushDown::Exact
+            && mdb_filter_needs_local_evaluation(filter, args)
+        {
+            return Ok(TableProviderFilterPushDown::Inexact);
+        }
 
         Ok(pushdown)
     }


### PR DESCRIPTION
Fixes two defects in the `.mdb` (Jet) backend and adds filter-pushdown coverage. No `.accdb` / Access database type content: that lives in the follow-up PR.

## Fix 1: filters on Money/Binary/OLE columns returned unfiltered rows

`select "ProductID" from Products where "UnitPrice" > 20` returned all 77 rows instead of 37.

Two things line up to produce this:

- `libmdbodbc.so` applies `WHERE` predicates through `mdb_test_sarg()`, which has no case for the Money, Numeric, Binary, Complex or OLE column types. It leaves its result variable at the initial "row matches" value and only prints `Calling mdb_test_sarg on unknown type` to stderr, so nothing is filtered remotely.
- the crate reported such a filter as `TableProviderFilterPushDown::Exact`, so DataFusion trusted the remote result and did not filter locally either.

Neither side filtered, and the result was silently wrong rather than an error.

Filters that read a column of one of those types are now reported as `Inexact`, which keeps a local `FilterExec` in the plan; every other column type still pushes down as `Exact`. To decide this, the real remote schema is now passed into the pushdown decision (`table.rs`).

## Fix 2: connections failed depending on heap layout

`SQLDriverConnect` failed with `NoDiagnostics` and a `File not found` line on stderr for a file that exists. A 126-character DBQ path failed 10/10 times while a shorter spelling of the same path succeeded 10/10 times.

An `LD_PRELOAD` shim around `stat` showed the path the driver actually resolved had a stray byte appended: `.../ASampleDatabase.accdb1`. `libmdbodbc.so` ignores the `cbConnStrIn` length passed to `SQLDriverConnect` and reads the connection string as a NUL-terminated C string, while `odbc-api` hands it the bytes of a Rust `&str`, which carry no terminator. The driver reads past the end of the buffer and appends whatever it finds in adjacent heap memory to the `DBQ` path, so whether a connection succeeds depends on heap layout.

The connection string is now built with `CString`, which owns a NUL-terminated buffer; `to_str()` borrows exactly its length, so the driver stops at the terminator we own (and the length handed to drivers that do honour `cbConnStrIn` stays honest). This is likely the real cause of the "process-global state corruption" documented above `MDB_CONN_CACHE`, which was worked around with a shared connection cache.

## Tests

Four filter tests over `nwind.mdb`, each running against a table source and a query source: Currency (`Products.UnitPrice`, re-checked locally), text (`ProductName LIKE`, pushed down), and integer (`Orders.OrderID`, pushed down). Expected rows are derived from the fixture file rather than from the query path under test. The Currency case also asserts that a LIMIT is not pushed into the scan, since the scan would otherwise truncate the table before the local filter runs.

Also lists MDB in the README's supported databases (it was missing).

## Verification

```
cargo test -p integration-tests --test mdb     # 23 passed
cargo fmt --all -- --check
cargo clippy --all -- -D warnings
cargo check -p datafusion-remote-table --no-default-features --features mdb
cargo check -p datafusion-remote-table --all-features
```

Only the `mdb` integration target was run locally; the other backends need their containers.
