### PR TITLE
feat(access): add Access (.accdb) as its own remote database type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Build with only mdb
         run: cargo check -p datafusion-remote-table --no-default-features --features mdb
 
+      - name: Build with only access
+        run: cargo check -p datafusion-remote-table --no-default-features --features access
+
       - name: Build with only gaussdb
         run: cargo check -p datafusion-remote-table --no-default-features --features gaussdb
 
@@ -80,7 +83,7 @@ jobs:
 
       - name: Run integration tests
         # There is no easy way to install dm odbc driver, so skip dm integration tests
-        run: cargo test -p integration-tests --test common --test sqlite --test postgres --test mysql --test oracle --test mdb --test gaussdb
+        run: cargo test -p integration-tests --test common --test sqlite --test postgres --test mysql --test oracle --test mdb --test access --test gaussdb
 
   lints:
     name: Lints

--- a/README.md
+++ b/README.md
@@ -85,11 +85,17 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
   - [x] Int2[] / Int4[] / Int8[]
   - [x] Float4[] / Float8[]
   - [x] Varchar[] / Text[] / Bool[]
-- [x] MDB (Microsoft Access, via the MDBTools ODBC driver)
+- [x] MDB (Microsoft Access `.mdb`, Jet engine, via the MDBTools ODBC driver)
   - [x] Byte / Small Integer / Long Integer / Bit
   - [x] Real / Double / Currency
   - [x] Text / Memo / Binary / OLE / Guid
   - [x] Date / Time / DateTime
+- [x] Access (Microsoft Access `.accdb`, ACE engine, via the MDBTools ODBC driver)
+  - [x] Byte / Small Integer / Long Integer / Bit
+  - [x] Real / Double / Currency
+  - [x] Text / Memo / Binary / OLE / Guid
+  - [x] Date / Time / DateTime
+  - [x] Own type enum, options, pool and connection handling; tables are listed through the `MSysObjects` catalog table
 
 ## Thanks
 - [datafusion-table-providers](https://crates.io/crates/datafusion-table-providers)

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-datafusion-remote-table = { path = "../remote-table", features = ["postgres", "mysql", "oracle", "sqlite", "dm", "mdb", "gaussdb"] }
+datafusion-remote-table = { path = "../remote-table", features = ["postgres", "mysql", "oracle", "sqlite", "dm", "mdb", "access", "gaussdb"] }
 datafusion = { workspace = true }
 datafusion-proto = { workspace = true }
 tokio = { workspace = true }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -110,6 +110,47 @@ pub fn setup_mdb() -> &'static Path {
     })
 }
 
+static ACCDB_DB: OnceLock<PathBuf> = OnceLock::new();
+
+/// Returns the path to the ACCDB (Access 2007+ / ACE engine) test database file.
+///
+/// Downloads `data/ASampleDatabase.accdb` (544,768 bytes) from the same pinned
+/// commit of the mdbtools/mdbtestdata repo used by [`setup_mdb`]. The file is
+/// cached at `target/ASampleDatabase.accdb`; subsequent invocations reuse the
+/// cached copy when its size matches `EXPECTED_SIZE`.
+///
+/// mdbtools' own test suite exercises this file through the `MDBTools` ODBC
+/// driver, so it covers the ACE code path that `nwind.mdb` (JET3) does not.
+pub fn setup_accdb() -> &'static Path {
+    const URL: &str = "https://raw.githubusercontent.com/mdbtools/mdbtestdata/\
+        5ebf2d685ec628df72f4774b78abee96a866b837/data/ASampleDatabase.accdb";
+    const EXPECTED_SIZE: u64 = 544_768;
+
+    ACCDB_DB.get_or_init(|| {
+        let db_path = PathBuf::from(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../target/ASampleDatabase.accdb"
+        ));
+        let needs_download = std::fs::metadata(&db_path)
+            .map(|m| m.len() != EXPECTED_SIZE)
+            .unwrap_or(true);
+        if needs_download {
+            let status = std::process::Command::new("curl")
+                .args(["-fsSL", "--retry", "3", "-o"])
+                .arg(&db_path)
+                .arg(URL)
+                .status()
+                .expect(
+                    "failed to invoke curl to fetch ASampleDatabase.accdb (is curl installed?)",
+                );
+            if !status.success() {
+                panic!("Failed to download ACCDB fixture from {URL}");
+            }
+        }
+        db_path
+    })
+}
+
 static GAUSSDB_DB: OnceLock<DockerCompose> = OnceLock::new();
 pub async fn setup_gaussdb_db() {
     let _ = GAUSSDB_DB.get_or_init(|| {

--- a/integration-tests/src/utils.rs
+++ b/integration-tests/src/utils.rs
@@ -4,9 +4,9 @@ use datafusion::physical_plan::collect;
 use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion_remote_table::{
-    ConnectionOptions, DmConnectionOptions, MdbConnectionOptions, MysqlConnectionOptions,
-    OracleConnectionOptions, PostgresConnectionOptions, RemoteDbType, RemoteSource, RemoteTable,
-    SqliteConnectionOptions,
+    AccessConnectionOptions, ConnectionOptions, DmConnectionOptions, MdbConnectionOptions,
+    MysqlConnectionOptions, OracleConnectionOptions, PostgresConnectionOptions, RemoteDbType,
+    RemoteSource, RemoteTable, SqliteConnectionOptions,
 };
 use std::sync::Arc;
 
@@ -142,6 +142,9 @@ pub fn build_conn_options(database: RemoteDbType) -> ConnectionOptions {
         RemoteDbType::Mdb => {
             ConnectionOptions::Mdb(MdbConnectionOptions::new(crate::setup_mdb().to_path_buf()))
         }
+        RemoteDbType::Access => ConnectionOptions::Access(AccessConnectionOptions::new(
+            crate::setup_accdb().to_path_buf(),
+        )),
         RemoteDbType::GaussDB => {
             use datafusion_remote_table::GaussDBConnectionOptions;
             ConnectionOptions::GaussDB(

--- a/integration-tests/testdata/access/README.md
+++ b/integration-tests/testdata/access/README.md
@@ -1,0 +1,52 @@
+# Access Test Fixture
+
+How to set up an Access (`.accdb`, ACE engine) integration-test environment on
+Linux.
+
+The `.accdb` fixture is fetched automatically at test time. The ODBC driver is
+the same `MDBTools` driver the `.mdb` tests use, so the driver setup is shared:
+see [`../mdb/README.md`](../mdb/README.md) for installing unixODBC, building
+mdbtools and registering the driver.
+
+## Fixture
+
+`integration-tests::setup_accdb()` downloads
+[`data/ASampleDatabase.accdb`](https://github.com/mdbtools/mdbtestdata/blob/5ebf2d685ec628df72f4774b78abee96a866b837/data/ASampleDatabase.accdb)
+(544,768 bytes) from the same pinned [`mdbtools/mdbtestdata`](https://github.com/mdbtools/mdbtestdata)
+commit as `nwind.mdb`, and caches it at `target/ASampleDatabase.accdb`. The URL
+is pinned to a specific commit SHA so the fixture is byte-stable across runs and
+across upstream changes. Subsequent test runs reuse the cached file when its
+size matches the expected 544,768 bytes.
+
+The file is an Access 2007 database (`ACE12`), so it exercises the ACE code path
+that the JET3 `nwind.mdb` does not. mdbtools' own test suite runs against it as
+well, so the `MDBTools` ODBC driver is known to be compatible with it.
+
+The tests use the `Asset Items` table (65 rows). ACE files have a real catalog
+table, so listing tables and stored queries means querying `MSysObjects` like
+any other source (`Type` 1 = local table, 5 = stored query); the file's stored
+queries are `qryComputerHardwareInOwnerOrder`, `qryCostsSummedByOwner` and
+`qryGSTCalculations`.
+
+## Tests
+
+`integration-tests/tests/access.rs` runs against this fixture through
+`RemoteDbType::Access` / `ConnectionOptions::Access`: basic queries over table
+and query sources, filter pushdown on a Currency column, listing the tables and
+stored queries through the `MSysObjects` catalog table, a physical-plan
+serialization round trip, and pool state.
+
+## Troubleshooting
+
+`SQLDriverConnect` failures, missing driver libraries and fixture download
+problems are documented in [`../mdb/README.md`](../mdb/README.md); the checks
+are the same, with `target/ASampleDatabase.accdb` (544,768 bytes) as the fixture
+to verify.
+
+One driver detail worth knowing when connecting through `odbc-api`:
+`libmdbodbc.so` ignores the connection-string length passed to
+`SQLDriverConnect` and reads the string as a NUL-terminated C string. A caller
+that passes a non-terminated buffer (a Rust `&str`, for example) has the driver
+read into adjacent memory and append garbage to the `DBQ` path, which surfaces
+as `NoDiagnostics` plus a `File not found` line on stderr for a file that
+exists. The backend passes a `CString` to avoid it.

--- a/integration-tests/tests/access.rs
+++ b/integration-tests/tests/access.rs
@@ -1,0 +1,370 @@
+use datafusion::arrow::util::pretty::pretty_format_batches;
+use datafusion::physical_plan::collect;
+use datafusion::physical_plan::display::DisplayableExecutionPlan;
+use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion_proto::physical_plan::AsExecutionPlan;
+use datafusion_proto::protobuf::PhysicalPlanNode;
+use datafusion_remote_table::{
+    AccessConnectionOptions, ConnectionOptions, RemoteDbType, RemotePhysicalCodec, RemoteSource,
+    RemoteTable,
+};
+use integration_tests::setup_accdb;
+use integration_tests::utils::{assert_plan_and_result, assert_result, build_conn_options};
+use std::sync::Arc;
+
+/// The Access fixture (`ASampleDatabase.accdb`) uses the ACE engine, so these
+/// tests cover `.accdb` files through `RemoteDbType::Access`. `.mdb` files are
+/// covered by `mdb.rs`; the two backends are independent, so the tests mirror
+/// each other rather than share fixtures.
+
+#[rstest::rstest]
+#[case("SELECT * FROM \"Asset Items\"".into())]
+#[case(vec!["Asset Items"].into())]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_basic_query(#[case] source: RemoteSource) {
+    assert_plan_and_result(
+        RemoteDbType::Access,
+        source,
+        "select \"Asset No\", \"Make\", \"Cost\" from remote_table limit 3",
+        vec![
+            "CooperativeExec\n  RemoteTableScanExec: source=query, projection=[Asset No, Make, Cost], limit=3\n",
+            "CooperativeExec\n  RemoteTableScanExec: source=Asset Items, projection=[Asset No, Make, Cost], limit=3\n",
+        ],
+        r#"+----------+------------+-----------+
+| Asset No | Make       | Cost      |
++----------+------------+-----------+
+| 30050    | GEO Rocket | 1995.5000 |
+| 30051    | GEO Blast  | 2450.0000 |
+| 30052    | FurnTown   | 244.0000  |
++----------+------------+-----------+"#,
+    )
+    .await;
+}
+
+#[rstest::rstest]
+#[case("SELECT * FROM \"Asset Items\"".into())]
+#[case(vec!["Asset Items"].into())]
+#[tokio::test(flavor = "multi_thread")]
+async fn filter_on_currency_column(#[case] source: RemoteSource) {
+    // Cost is a Currency column, which mdbtools' mdb_test_sarg() cannot compare,
+    // so the filter is classified as inexact and DataFusion re-checks it locally.
+    assert_plan_and_result(
+        RemoteDbType::Access,
+        source,
+        "select \"Asset No\", \"Cost\" from remote_table \
+         where \"Cost\" > 1000 order by \"Asset No\" limit 5",
+        vec![
+            "SortPreservingMergeExec: [Asset No@0 ASC NULLS LAST], fetch=5\n  SortExec: TopK(fetch=5), expr=[Asset No@0 ASC NULLS LAST], preserve_partitioning=[true]\n    FilterExec: Cost@1 > 1000.0000\n      RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1\n        RemoteTableScanExec: source=query, projection=[Asset No, Cost]\n",
+            "SortPreservingMergeExec: [Asset No@0 ASC NULLS LAST], fetch=5\n  SortExec: TopK(fetch=5), expr=[Asset No@0 ASC NULLS LAST], preserve_partitioning=[true]\n    FilterExec: Cost@1 > 1000.0000\n      RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1\n        RemoteTableScanExec: source=Asset Items, projection=[Asset No, Cost], filters=[(\"Cost\" > 1000.0000)]\n",
+        ],
+        r#"+----------+-----------+
+| Asset No | Cost      |
++----------+-----------+
+| 30050    | 1995.5000 |
+| 30051    | 2450.0000 |
+| 30054    | 2560.0000 |
+| 30055    | 5433.0000 |
+| 30058    | 1255.0000 |
++----------+-----------+"#,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_tables_through_msys_objects() {
+    // `.accdb` sources have no list-tables command: an ACE file has a real
+    // catalog table, so the tables and stored queries are read from it like any
+    // other source. Type 1 = local table, 5 = stored query.
+    assert_result(
+        RemoteDbType::Access,
+        vec!["MSysObjects"],
+        r#"select "Name", "Type" from remote_table where "Type" = 5 and "Name" like 'qry%' order by "Name""#,
+        r#"+---------------------------------+------+
+| Name                            | Type |
++---------------------------------+------+
+| qryComputerHardwareInOwnerOrder | 5    |
+| qryCostsSummedByOwner           | 5    |
+| qryGSTCalculations              | 5    |
++---------------------------------+------+"#,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn pool_state() {
+    let options = build_conn_options(RemoteDbType::Access);
+    let pool = datafusion_remote_table::connect(&options).await.unwrap();
+
+    let conn = pool.get().await.unwrap();
+    assert_eq!(pool.state().await.unwrap().connections, 1);
+    drop(conn);
+    assert_eq!(pool.state().await.unwrap().connections, 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn serialization_round_trip() {
+    let options = build_conn_options(RemoteDbType::Access);
+    let table = RemoteTable::try_new(options, vec!["Asset Items"])
+        .await
+        .unwrap();
+
+    let ctx = SessionContext::new();
+    ctx.register_table("remote_table", Arc::new(table)).unwrap();
+
+    let df = ctx
+        .sql("select \"Asset No\", \"Cost\" from remote_table where \"Cost\" > 4000 order by \"Asset No\"")
+        .await
+        .unwrap();
+    let plan = df.create_physical_plan().await.unwrap();
+
+    // The Access connection options travel through the plan as their own
+    // oneof field, so a round trip has to keep the database type intact.
+    let codec = RemotePhysicalCodec::new();
+    let mut plan_buf: Vec<u8> = vec![];
+    let plan_proto = PhysicalPlanNode::try_from_physical_plan(plan, &codec).unwrap();
+    plan_proto.try_encode(&mut plan_buf).unwrap();
+    let new_plan = PhysicalPlanNode::try_decode(&plan_buf)
+        .and_then(|proto| proto.try_into_physical_plan(&ctx.task_ctx(), &codec))
+        .unwrap();
+    println!(
+        "deserialized plan: {}",
+        DisplayableExecutionPlan::new(new_plan.as_ref()).indent(true)
+    );
+
+    let batches = collect(new_plan, ctx.task_ctx()).await.unwrap();
+    assert_eq!(
+        datafusion::arrow::util::pretty::pretty_format_batches(&batches)
+            .unwrap()
+            .to_string(),
+        r#"+----------+-----------+
+| Asset No | Cost      |
++----------+-----------+
+| 30055    | 5433.0000 |
+| 30071    | 6799.0000 |
+| 30090    | 5433.0000 |
+| 30110    | 5999.0000 |
++----------+-----------+"#
+    );
+}
+
+#[rstest::rstest]
+#[case("SELECT * FROM \"Asset Items\"".into())]
+#[case(vec!["Asset Items"].into())]
+#[tokio::test(flavor = "multi_thread")]
+async fn pushdown_limit(#[case] source: RemoteSource) {
+    assert_plan_and_result(
+        RemoteDbType::Access,
+        source,
+        "select \"Asset No\", \"Make\", \"Cost\" from remote_table limit 2",
+        vec![
+            "CooperativeExec\n  RemoteTableScanExec: source=query, projection=[Asset No, Make, Cost], limit=2\n",
+            "CooperativeExec\n  RemoteTableScanExec: source=Asset Items, projection=[Asset No, Make, Cost], limit=2\n",
+        ],
+        r#"+----------+------------+-----------+
+| Asset No | Make       | Cost      |
++----------+------------+-----------+
+| 30050    | GEO Rocket | 1995.5000 |
+| 30051    | GEO Blast  | 2450.0000 |
++----------+------------+-----------+"#,
+    )
+    .await;
+}
+
+#[rstest::rstest]
+#[case("SELECT * FROM \"Asset Items\"".into())]
+#[case(vec!["Asset Items"].into())]
+#[tokio::test(flavor = "multi_thread")]
+async fn count1_agg(#[case] source: RemoteSource) {
+    // Table source: COUNT pushdown via the Access row-count fast path
+    // Query source: COUNT via DataFusion aggregate (no pushdown)
+    let query_plan = "ProjectionExec: expr=[count(Int64(1))@0 as count(*)]\n  \
+         AggregateExec: mode=Final, gby=[], aggr=[count(Int64(1))]\n    \
+         CoalescePartitionsExec\n      \
+         AggregateExec: mode=Partial, gby=[], aggr=[count(Int64(1))]\n        \
+         RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1\n          \
+         RemoteTableScanExec: source=query, projection=[]\n"
+        .to_string();
+    let expected_plans: Vec<&str> = match &source {
+        RemoteSource::Table(_) => {
+            vec!["ProjectionExec: expr=[65 as count(*)]\n  PlaceholderRowExec\n"]
+        }
+        RemoteSource::Query(_) => vec![&query_plan],
+        RemoteSource::Command(_) => unreachable!("Command not used in this test"),
+    };
+    assert_plan_and_result(
+        RemoteDbType::Access,
+        source,
+        "select count(*) from remote_table",
+        expected_plans,
+        r#"+----------+
+| count(*) |
++----------+
+| 65       |
++----------+"#,
+    )
+    .await;
+}
+
+#[rstest::rstest]
+#[case("SELECT * FROM \"Asset Items\"".into())]
+#[case(vec!["Asset Items"].into())]
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_projection(#[case] source: RemoteSource) {
+    let options = build_conn_options(RemoteDbType::Access);
+    let table = RemoteTable::try_new(options, source).await.unwrap();
+
+    let config = SessionConfig::new().with_target_partitions(12);
+    let ctx = SessionContext::new_with_config(config);
+
+    let df = ctx.read_table(Arc::new(table)).unwrap();
+    let df = df.select_columns(&[]).unwrap();
+
+    let exec_plan = df.create_physical_plan().await.unwrap();
+    let plan_display = DisplayableExecutionPlan::new(exec_plan.as_ref())
+        .indent(true)
+        .to_string();
+    println!("{plan_display}");
+    assert!(
+        [
+            "CooperativeExec\n  RemoteTableScanExec: source=query, projection=[]\n",
+            "CooperativeExec\n  RemoteTableScanExec: source=Asset Items, projection=[]\n",
+        ]
+        .contains(&plan_display.as_str())
+    );
+
+    let result = collect(exec_plan, ctx.task_ctx()).await.unwrap();
+    assert_eq!(result.len(), 1);
+    let batch = &result[0];
+    assert_eq!(batch.num_columns(), 0);
+    assert_eq!(batch.num_rows(), 65);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn asset_items_table_with_various_types() {
+    assert_result(
+        RemoteDbType::Access,
+        vec!["Asset Items"],
+        "select * from remote_table limit 2",
+        r#"+----------+-------------------+------------+------------+-------------+-------+-----------+---------------------+-----------+----------+-----------+-------------+----------+
+| Asset No | Asset Category    | Make       | Model      | Description | Owner | Serial No | Acquired            | Cost      | Warranty | Tax Scale | Supplier No | Comments |
++----------+-------------------+------------+------------+-------------+-------+-----------+---------------------+-----------+----------+-----------+-------------+----------+
+| 30050    | Computer Hardware | GEO Rocket | 220ZX      | Computer    | Sales | 344-667   | 1997-09-02T00:00:00 | 1995.5000 | 12       | A         | 44577       |          |
+| 30051    | Computer Hardware | GEO Blast  | Surger 350 | Computer    | Sales | 345-556   | 1997-09-02T00:00:00 | 2450.0000 | 12       | A         | 44577       |          |
++----------+-------------------+------------+------------+-------------+-------+-----------+---------------------+-----------+----------+-----------+-------------+----------+"#,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+pub async fn streaming_execution() {
+    let options = ConnectionOptions::Access(
+        AccessConnectionOptions::new(setup_accdb().to_path_buf()).with_stream_chunk_size(1usize),
+    );
+    let table = RemoteTable::try_new(options, RemoteSource::from(vec!["Asset Items"]))
+        .await
+        .unwrap();
+
+    let ctx = SessionContext::new();
+    ctx.register_table("remote_table", Arc::new(table)).unwrap();
+
+    let df = ctx
+        .sql("select \"Asset No\", \"Make\" from remote_table where \"Asset No\" < '30053' order by \"Asset No\"")
+        .await
+        .unwrap();
+    let exec_plan = df.create_physical_plan().await.unwrap();
+    println!(
+        "{}",
+        DisplayableExecutionPlan::new(exec_plan.as_ref()).indent(true)
+    );
+
+    let result = collect(exec_plan, ctx.task_ctx()).await.unwrap();
+    assert_eq!(
+        pretty_format_batches(&result).unwrap().to_string(),
+        r#"+----------+------------+
+| Asset No | Make       |
++----------+------------+
+| 30050    | GEO Rocket |
+| 30051    | GEO Blast  |
+| 30052    | FurnTown   |
++----------+------------+"#
+    );
+}
+
+#[rstest::rstest]
+#[case("SELECT * FROM \"Asset Items\" WHERE \"Asset No\" = '30050'".into())]
+#[case(vec!["Asset Items"].into())]
+#[tokio::test(flavor = "multi_thread")]
+async fn pushdown_filters(#[case] source: RemoteSource) {
+    // Table sources: filters pushed via rewrite_query (no unparser needed)
+    // Query sources: filters applied via DataFusion FilterExec (unparser unsupported)
+    assert_plan_and_result(
+        RemoteDbType::Access,
+        source,
+        "select \"Asset No\", \"Make\", \"Cost\" from remote_table where \"Asset No\" = '30050'",
+        vec![
+            "FilterExec: Asset No@0 = 30050\n  RepartitionExec: partitioning=RoundRobinBatch(12), input_partitions=1\n    RemoteTableScanExec: source=query, projection=[Asset No, Make, Cost]\n",
+            "CooperativeExec\n  RemoteTableScanExec: source=Asset Items, projection=[Asset No, Make, Cost], filters=[(\"Asset No\" = '30050')]\n",
+        ],
+        r#"+----------+------------+-----------+
+| Asset No | Make       | Cost      |
++----------+------------+-----------+
+| 30050    | GEO Rocket | 1995.5000 |
++----------+------------+-----------+"#,
+    )
+    .await;
+}
+
+#[rstest::rstest]
+#[case("SELECT * FROM \"Asset Items\" WHERE \"Make\" LIKE 'GEO%'".into())]
+#[case(vec!["Asset Items"].into())]
+#[tokio::test(flavor = "multi_thread")]
+async fn filter_on_text_column(#[case] source: RemoteSource) {
+    // Text comparisons are supported by mdb_test_sarg(), so the filter stays
+    // pushed down on a table source and results are still correct.
+    assert_result(
+        RemoteDbType::Access,
+        source,
+        "select \"Asset No\", \"Make\" from remote_table where \"Make\" like 'GEO%' order by \"Asset No\"",
+        r#"+----------+------------+
+| Asset No | Make       |
++----------+------------+
+| 30050    | GEO Rocket |
+| 30051    | GEO Blast  |
+| 30054    | GEO Blast  |
+| 30055    | GEO Blast  |
+| 30066    | GEO Rocket |
+| 30067    | GEO Rocket |
+| 30089    | GEO Blast  |
+| 30090    | GEO Blast  |
+| 30102    | GEO Rocket |
+| 30104    | GEO Rocket |
+| 30105    | GEO Rocket |
+| 30110    | GEO Blast  |
++----------+------------+"#,
+    )
+    .await;
+}
+
+#[rstest::rstest]
+#[case("SELECT * FROM \"Asset Items\" WHERE \"Warranty\" > 12".into())]
+#[case(vec!["Asset Items"].into())]
+#[tokio::test(flavor = "multi_thread")]
+async fn filter_on_integer_column(#[case] source: RemoteSource) {
+    // Integer comparisons are supported by mdb_test_sarg().
+    assert_result(
+        RemoteDbType::Access,
+        source,
+        "select \"Asset No\", \"Warranty\" from remote_table where \"Warranty\" > 12 order by \"Asset No\"",
+        r#"+----------+----------+
+| Asset No | Warranty |
++----------+----------+
+| 30055    | 24       |
+| 30071    | 24       |
+| 30072    | 24       |
+| 30090    | 24       |
+| 30108    | 24       |
+| 30110    | 24       |
++----------+----------+"#,
+    )
+    .await;
+}

--- a/remote-table/Cargo.toml
+++ b/remote-table/Cargo.toml
@@ -17,6 +17,7 @@ oracle = ["dep:bb8", "dep:oracle", "dep:bb8-oracle"]
 sqlite = ["dep:rusqlite"]
 dm = ["dep:odbc-api"]
 mdb = ["dep:odbc-api"]
+access = ["dep:odbc-api"]
 gaussdb = ["dep:bb8", "dep:bb8-gaussdb"]
 
 [dependencies]

--- a/remote-table/gen/proto/remote_table.proto
+++ b/remote-table/gen/proto/remote_table.proto
@@ -40,6 +40,8 @@ message ConnectionOptions {
     DmConnectionOptions dm = 5;
     MdbConnectionOptions mdb = 6;
     GaussDBConnectionOptions gaussdb = 7;
+    // Microsoft Access .accdb (ACE engine).
+    AccessConnectionOptions access = 8;
   }
 }
 
@@ -49,12 +51,20 @@ message MdbConnectionOptions {
   uint32 stream_chunk_size = 3;
   optional string uid = 4;
   optional string pwd = 5;
-  repeated MdbExtraParam extra_params = 6;
+  // ODBC connection attributes passed through verbatim. Serialized in key
+  // order so encoded plans are byte-stable.
+  map<string, string> extra_params = 6;
 }
 
-message MdbExtraParam {
-  string key = 1;
-  string value = 2;
+message AccessConnectionOptions {
+  string path = 1;
+  string driver = 2;
+  uint32 stream_chunk_size = 3;
+  optional string uid = 4;
+  optional string pwd = 5;
+  // ODBC connection attributes passed through verbatim. Serialized in key
+  // order so encoded plans are byte-stable.
+  map<string, string> extra_params = 6;
 }
 
 message RemoteSource {
@@ -280,6 +290,21 @@ message RemoteType {
     Empty mdb_date_time = 513;
     Empty mdb_date = 514;
     Empty mdb_time = 515;
+    Empty access_bit = 701;
+    Empty access_tiny_int = 702;
+    Empty access_small_int = 703;
+    Empty access_integer = 704;
+    Empty access_real = 705;
+    Empty access_double = 706;
+    Empty access_currency = 707;
+    AccessText access_text = 708;
+    Empty access_memo = 709;
+    AccessBinary access_binary = 710;
+    Empty access_ole_object = 711;
+    Empty access_guid = 712;
+    Empty access_date_time = 713;
+    Empty access_date = 714;
+    Empty access_time = 715;
     Empty gaussdb_int2 = 601;
     Empty gaussdb_int4 = 602;
     Empty gaussdb_int8 = 603;
@@ -316,6 +341,14 @@ message RemoteType {
 }
 
 message MdbText {
+  optional uint32 length = 1;
+}
+
+message AccessText {
+  optional uint32 length = 1;
+}
+
+message AccessBinary {
   optional uint32 length = 1;
 }
 

--- a/remote-table/src/codec.rs
+++ b/remote-table/src/codec.rs
@@ -1,3 +1,4 @@
+use crate::AccessConnectionOptions;
 use crate::DmConnectionOptions;
 use crate::GaussDBConnectionOptions;
 use crate::GaussDBType;
@@ -9,9 +10,10 @@ use crate::PostgresConnectionOptions;
 use crate::SqliteConnectionOptions;
 use crate::generated::prost as protobuf;
 use crate::{
-    ConnectionOptions, DFResult, DefaultLiteralizer, DefaultTransform, DmType, Literalize, MdbType,
-    MysqlType, OracleType, PostgresType, RemoteField, RemoteSchema, RemoteSchemaRef, RemoteSource,
-    RemoteTableInsertExec, RemoteTableScanExec, RemoteType, SourceCommand, SqliteType, Transform,
+    AccessType, ConnectionOptions, DFResult, DefaultLiteralizer, DefaultTransform, DmType,
+    Literalize, MdbType, MysqlType, OracleType, PostgresType, RemoteField, RemoteSchema,
+    RemoteSchemaRef, RemoteSource, RemoteTableInsertExec, RemoteTableScanExec, RemoteType,
+    SourceCommand, SqliteType, Transform,
 };
 use arrow::datatypes::SchemaRef;
 use datafusion_common::DataFusionError;
@@ -289,6 +291,70 @@ impl PhysicalExtensionCodec for RemotePhysicalCodec {
     }
 }
 
+fn serialize_mdb_options(options: &MdbConnectionOptions) -> protobuf::MdbConnectionOptions {
+    protobuf::MdbConnectionOptions {
+        path: options.path.to_str().unwrap_or("").to_string(),
+        driver: options.driver.clone(),
+        stream_chunk_size: options.stream_chunk_size as u32,
+        uid: options.uid.clone(),
+        pwd: options.pwd.clone(),
+        extra_params: options.extra_params.clone(),
+    }
+}
+
+fn deserialize_mdb_options(options: protobuf::MdbConnectionOptions) -> MdbConnectionOptions {
+    let mut mdb_options =
+        MdbConnectionOptions::new(std::path::Path::new(&options.path).to_path_buf());
+    if !options.driver.is_empty() {
+        mdb_options.driver = options.driver;
+    }
+    if options.stream_chunk_size > 0 {
+        mdb_options.stream_chunk_size = options.stream_chunk_size as usize;
+    }
+    if let Some(uid) = options.uid {
+        mdb_options.uid = Some(uid);
+    }
+    if let Some(pwd) = options.pwd {
+        mdb_options.pwd = Some(pwd);
+    }
+    mdb_options.extra_params = options.extra_params;
+    mdb_options
+}
+
+fn serialize_access_options(
+    options: &AccessConnectionOptions,
+) -> protobuf::AccessConnectionOptions {
+    protobuf::AccessConnectionOptions {
+        path: options.path.to_str().unwrap_or("").to_string(),
+        driver: options.driver.clone(),
+        stream_chunk_size: options.stream_chunk_size as u32,
+        uid: options.uid.clone(),
+        pwd: options.pwd.clone(),
+        extra_params: options.extra_params.clone(),
+    }
+}
+
+fn deserialize_access_options(
+    options: protobuf::AccessConnectionOptions,
+) -> AccessConnectionOptions {
+    let mut access_options =
+        AccessConnectionOptions::new(std::path::Path::new(&options.path).to_path_buf());
+    if !options.driver.is_empty() {
+        access_options.driver = options.driver;
+    }
+    if options.stream_chunk_size > 0 {
+        access_options.stream_chunk_size = options.stream_chunk_size as usize;
+    }
+    if let Some(uid) = options.uid {
+        access_options.uid = Some(uid);
+    }
+    if let Some(pwd) = options.pwd {
+        access_options.pwd = Some(pwd);
+    }
+    access_options.extra_params = options.extra_params;
+    access_options
+}
+
 fn serialize_connection_options(options: &ConnectionOptions) -> protobuf::ConnectionOptions {
     match options {
         ConnectionOptions::Postgres(options) => protobuf::ConnectionOptions {
@@ -369,21 +435,12 @@ fn serialize_connection_options(options: &ConnectionOptions) -> protobuf::Connec
         },
         ConnectionOptions::Mdb(options) => protobuf::ConnectionOptions {
             connection_options: Some(protobuf::connection_options::ConnectionOptions::Mdb(
-                protobuf::MdbConnectionOptions {
-                    path: options.path.to_str().unwrap_or("").to_string(),
-                    driver: options.driver.clone(),
-                    stream_chunk_size: options.stream_chunk_size as u32,
-                    uid: options.uid.clone(),
-                    pwd: options.pwd.clone(),
-                    extra_params: options
-                        .extra_params
-                        .iter()
-                        .map(|(k, v)| protobuf::MdbExtraParam {
-                            key: k.clone(),
-                            value: v.clone(),
-                        })
-                        .collect(),
-                },
+                serialize_mdb_options(options),
+            )),
+        },
+        ConnectionOptions::Access(options) => protobuf::ConnectionOptions {
+            connection_options: Some(protobuf::connection_options::ConnectionOptions::Access(
+                serialize_access_options(options),
             )),
         },
         ConnectionOptions::GaussDB(options) => protobuf::ConnectionOptions {
@@ -470,28 +527,10 @@ fn parse_connection_options(options: protobuf::ConnectionOptions) -> DFResult<Co
             })
         }
         Some(protobuf::connection_options::ConnectionOptions::Mdb(options)) => {
-            ConnectionOptions::Mdb({
-                let mut mdb_opts =
-                    MdbConnectionOptions::new(std::path::Path::new(&options.path).to_path_buf());
-                if !options.driver.is_empty() {
-                    mdb_opts.driver = options.driver;
-                }
-                if options.stream_chunk_size > 0 {
-                    mdb_opts.stream_chunk_size = options.stream_chunk_size as usize;
-                }
-                if let Some(uid) = options.uid {
-                    mdb_opts.uid = Some(uid);
-                }
-                if let Some(pwd) = options.pwd {
-                    mdb_opts.pwd = Some(pwd);
-                }
-                mdb_opts.extra_params = options
-                    .extra_params
-                    .into_iter()
-                    .map(|p| (p.key, p.value))
-                    .collect();
-                mdb_opts
-            })
+            ConnectionOptions::Mdb(deserialize_mdb_options(options))
+        }
+        Some(protobuf::connection_options::ConnectionOptions::Access(options)) => {
+            ConnectionOptions::Access(deserialize_access_options(options))
         }
         Some(protobuf::connection_options::ConnectionOptions::Gaussdb(options)) => {
             ConnectionOptions::GaussDB({
@@ -1084,6 +1123,73 @@ fn serialize_remote_type(remote_type: &RemoteType) -> protobuf::RemoteType {
         RemoteType::Mdb(MdbType::Time) => protobuf::RemoteType {
             r#type: Some(protobuf::remote_type::Type::MdbTime(protobuf::Empty {})),
         },
+        RemoteType::Access(AccessType::Bit) => protobuf::RemoteType {
+            r#type: Some(protobuf::remote_type::Type::AccessBit(protobuf::Empty {})),
+        },
+        RemoteType::Access(AccessType::TinyInt) => protobuf::RemoteType {
+            r#type: Some(protobuf::remote_type::Type::AccessTinyInt(
+                protobuf::Empty {},
+            )),
+        },
+        RemoteType::Access(AccessType::SmallInt) => protobuf::RemoteType {
+            r#type: Some(protobuf::remote_type::Type::AccessSmallInt(
+                protobuf::Empty {},
+            )),
+        },
+        RemoteType::Access(AccessType::Integer) => protobuf::RemoteType {
+            r#type: Some(protobuf::remote_type::Type::AccessInteger(
+                protobuf::Empty {},
+            )),
+        },
+        RemoteType::Access(AccessType::Real) => protobuf::RemoteType {
+            r#type: Some(protobuf::remote_type::Type::AccessReal(protobuf::Empty {})),
+        },
+        RemoteType::Access(AccessType::Double) => protobuf::RemoteType {
+            r#type: Some(protobuf::remote_type::Type::AccessDouble(
+                protobuf::Empty {},
+            )),
+        },
+        RemoteType::Access(AccessType::Currency) => protobuf::RemoteType {
+            r#type: Some(protobuf::remote_type::Type::AccessCurrency(
+                protobuf::Empty {},
+            )),
+        },
+        RemoteType::Access(AccessType::Text(len)) => protobuf::RemoteType {
+            r#type: Some(protobuf::remote_type::Type::AccessText(
+                protobuf::AccessText {
+                    length: len.map(|l| l as u32),
+                },
+            )),
+        },
+        RemoteType::Access(AccessType::Memo) => protobuf::RemoteType {
+            r#type: Some(protobuf::remote_type::Type::AccessMemo(protobuf::Empty {})),
+        },
+        RemoteType::Access(AccessType::Binary(len)) => protobuf::RemoteType {
+            r#type: Some(protobuf::remote_type::Type::AccessBinary(
+                protobuf::AccessBinary {
+                    length: len.map(|l| l as u32),
+                },
+            )),
+        },
+        RemoteType::Access(AccessType::OleObject) => protobuf::RemoteType {
+            r#type: Some(protobuf::remote_type::Type::AccessOleObject(
+                protobuf::Empty {},
+            )),
+        },
+        RemoteType::Access(AccessType::Guid) => protobuf::RemoteType {
+            r#type: Some(protobuf::remote_type::Type::AccessGuid(protobuf::Empty {})),
+        },
+        RemoteType::Access(AccessType::DateTime) => protobuf::RemoteType {
+            r#type: Some(protobuf::remote_type::Type::AccessDateTime(
+                protobuf::Empty {},
+            )),
+        },
+        RemoteType::Access(AccessType::Date) => protobuf::RemoteType {
+            r#type: Some(protobuf::remote_type::Type::AccessDate(protobuf::Empty {})),
+        },
+        RemoteType::Access(AccessType::Time) => protobuf::RemoteType {
+            r#type: Some(protobuf::remote_type::Type::AccessTime(protobuf::Empty {})),
+        },
         RemoteType::GaussDB(GaussDBType::Int2) => protobuf::RemoteType {
             r#type: Some(protobuf::remote_type::Type::GaussdbInt2(protobuf::Empty {})),
         },
@@ -1468,6 +1574,27 @@ fn parse_remote_type(remote_type: &protobuf::RemoteType) -> DFResult<RemoteType>
         protobuf::remote_type::Type::MdbDateTime(_) => RemoteType::Mdb(MdbType::DateTime),
         protobuf::remote_type::Type::MdbDate(_) => RemoteType::Mdb(MdbType::Date),
         protobuf::remote_type::Type::MdbTime(_) => RemoteType::Mdb(MdbType::Time),
+        protobuf::remote_type::Type::AccessBit(_) => RemoteType::Access(AccessType::Bit),
+        protobuf::remote_type::Type::AccessTinyInt(_) => RemoteType::Access(AccessType::TinyInt),
+        protobuf::remote_type::Type::AccessSmallInt(_) => RemoteType::Access(AccessType::SmallInt),
+        protobuf::remote_type::Type::AccessInteger(_) => RemoteType::Access(AccessType::Integer),
+        protobuf::remote_type::Type::AccessReal(_) => RemoteType::Access(AccessType::Real),
+        protobuf::remote_type::Type::AccessDouble(_) => RemoteType::Access(AccessType::Double),
+        protobuf::remote_type::Type::AccessCurrency(_) => RemoteType::Access(AccessType::Currency),
+        protobuf::remote_type::Type::AccessText(protobuf::AccessText { length }) => {
+            RemoteType::Access(AccessType::Text(length.map(|l| l as u16)))
+        }
+        protobuf::remote_type::Type::AccessMemo(_) => RemoteType::Access(AccessType::Memo),
+        protobuf::remote_type::Type::AccessBinary(protobuf::AccessBinary { length }) => {
+            RemoteType::Access(AccessType::Binary(length.map(|l| l as u16)))
+        }
+        protobuf::remote_type::Type::AccessOleObject(_) => {
+            RemoteType::Access(AccessType::OleObject)
+        }
+        protobuf::remote_type::Type::AccessGuid(_) => RemoteType::Access(AccessType::Guid),
+        protobuf::remote_type::Type::AccessDateTime(_) => RemoteType::Access(AccessType::DateTime),
+        protobuf::remote_type::Type::AccessDate(_) => RemoteType::Access(AccessType::Date),
+        protobuf::remote_type::Type::AccessTime(_) => RemoteType::Access(AccessType::Time),
         protobuf::remote_type::Type::GaussdbInt2(_) => RemoteType::GaussDB(GaussDBType::Int2),
         protobuf::remote_type::Type::GaussdbInt4(_) => RemoteType::GaussDB(GaussDBType::Int4),
         protobuf::remote_type::Type::GaussdbInt8(_) => RemoteType::GaussDB(GaussDBType::Int8),

--- a/remote-table/src/connection/access/mod.rs
+++ b/remote-table/src/connection/access/mod.rs
@@ -3,13 +3,10 @@ mod schema;
 
 use crate::connection::ODBC_ENV;
 use crate::{
-    Connection, ConnectionOptions, DFResult, Literalize, MdbConnectionOptions, MdbType, Pool,
-    PoolState, RemoteDbType, RemoteField, RemoteSchema, RemoteSchemaRef, RemoteSource, RemoteType,
-    SourceCommand,
+    AccessConnectionOptions, Connection, ConnectionOptions, DFResult, Literalize, Pool, PoolState,
+    RemoteDbType, RemoteSchemaRef, RemoteSource,
 };
-use arrow::array::ArrayRef;
 use arrow::array::RecordBatch;
-use arrow::array::StringBuilder;
 use arrow::array::make_builder;
 use arrow::datatypes::SchemaRef;
 use datafusion_common::DataFusionError;
@@ -32,27 +29,12 @@ use row::append_row_to_builders;
 use row::finish_batch;
 use schema::build_remote_schema;
 
-fn list_tables_remote_schema() -> RemoteSchema {
-    RemoteSchema::new(vec![
-        RemoteField::new(
-            "table_name",
-            RemoteType::Mdb(MdbType::Text(Some(255))),
-            false,
-        ),
-        RemoteField::new(
-            "table_type",
-            RemoteType::Mdb(MdbType::Text(Some(50))),
-            false,
-        ),
-    ])
-}
-
 /// Cache key that captures the full ODBC connection identity, not just the
-/// `.mdb` file path. Two pools that target the same path but use different
+/// `.accdb` file path. Two pools that target the same path but use different
 /// drivers, credentials, or extra connection parameters must NOT share a
 /// connection.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct MdbConnectionCacheKey {
+struct AccessConnectionCacheKey {
     path: PathBuf,
     driver: String,
     uid: Option<String>,
@@ -62,8 +44,8 @@ struct MdbConnectionCacheKey {
     extra_params: std::collections::BTreeMap<String, String>,
 }
 
-impl MdbConnectionCacheKey {
-    fn from_options(options: &MdbConnectionOptions) -> Self {
+impl AccessConnectionCacheKey {
+    fn from_options(options: &AccessConnectionOptions) -> Self {
         Self {
             path: options.path.clone(),
             driver: options.driver.clone(),
@@ -81,57 +63,57 @@ impl MdbConnectionCacheKey {
 /// Per-path global ODBC connection cache.
 ///
 /// mdbtools' `libmdbodbc.so` keeps process-global state and corrupts it after
-/// a handful of successive `SQLDriverConnect` calls to the same `.mdb` file
+/// a handful of successive `SQLDriverConnect` calls to the same `.accdb` file
 /// (observed symptom: `SQLDriverConnect: NoDiagnostics`, stderr says
 /// "File not found" while the file is plainly on disk). To work around this,
-/// every `MdbPool` that targets the same connection identity (path + driver +
+/// every `AccessPool` that targets the same connection identity (path + driver +
 /// uid + pwd + extra_params) shares a single underlying `odbc_api::Connection`.
 /// Concurrent access on that shared connection is still serialised by
-/// `MdbConnection`'s own mutex.
+/// `AccessConnection`'s own mutex.
 ///
 /// Cached connections live until process exit. Bounded by the number of
 /// distinct connection identities the process touches.
-static MDB_CONN_CACHE: OnceLock<
-    std::sync::Mutex<HashMap<MdbConnectionCacheKey, Arc<Mutex<odbc_api::Connection<'static>>>>>,
+static ACCESS_CONN_CACHE: OnceLock<
+    std::sync::Mutex<HashMap<AccessConnectionCacheKey, Arc<Mutex<odbc_api::Connection<'static>>>>>,
 > = OnceLock::new();
 
-fn mdb_conn_cache() -> &'static std::sync::Mutex<
-    HashMap<MdbConnectionCacheKey, Arc<Mutex<odbc_api::Connection<'static>>>>,
+fn access_conn_cache() -> &'static std::sync::Mutex<
+    HashMap<AccessConnectionCacheKey, Arc<Mutex<odbc_api::Connection<'static>>>>,
 > {
-    MDB_CONN_CACHE.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+    ACCESS_CONN_CACHE.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
 }
 
-pub struct MdbPool {
-    options: MdbConnectionOptions,
+pub struct AccessPool {
+    options: AccessConnectionOptions,
     connections: Arc<AtomicUsize>,
 }
 
-impl std::fmt::Debug for MdbPool {
+impl std::fmt::Debug for AccessPool {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MdbPool")
+        f.debug_struct("AccessPool")
             .field("options", &self.options)
             .field("connections", &self.connections)
             .finish()
     }
 }
 
-pub(crate) fn connect_mdb(options: &MdbConnectionOptions) -> DFResult<MdbPool> {
-    Ok(MdbPool {
+pub(crate) fn connect_access(options: &AccessConnectionOptions) -> DFResult<AccessPool> {
+    Ok(AccessPool {
         options: options.clone(),
         connections: Arc::new(AtomicUsize::new(0)),
     })
 }
 
 #[async_trait::async_trait]
-impl Pool for MdbPool {
+impl Pool for AccessPool {
     async fn get(&self) -> DFResult<Arc<dyn Connection>> {
-        let cache_key = MdbConnectionCacheKey::from_options(&self.options);
+        let cache_key = AccessConnectionCacheKey::from_options(&self.options);
 
-        // Consult the global cache (see MDB_CONN_CACHE). The cache lock is
+        // Consult the global cache (see ACCESS_CONN_CACHE). The cache lock is
         // held across the SQLDriverConnect call so two pools racing on the
         // same connection identity don't both open a connection.
         let conn = {
-            let mut cache = mdb_conn_cache().lock().unwrap();
+            let mut cache = access_conn_cache().lock().unwrap();
             if let Some(existing) = cache.get(&cache_key) {
                 existing.clone()
             } else {
@@ -149,13 +131,13 @@ impl Pool for MdbPool {
                 let connection_str =
                     CString::new(self.options.connection_string()).map_err(|e| {
                         DataFusionError::Execution(format!(
-                            "mdb connection string contains a NUL byte: {e}"
+                            "access connection string contains a NUL byte: {e}"
                         ))
                     })?;
                 let connection_str = connection_str
                     .to_str()
                     .expect("connection string built from a Rust String is valid UTF-8");
-                debug!("[remote-table] mdb connection string: {connection_str}");
+                debug!("[remote-table] access connection string: {connection_str}");
                 let connection = env
                     .connect_with_connection_string(
                         connection_str,
@@ -163,7 +145,7 @@ impl Pool for MdbPool {
                     )
                     .map_err(|e| {
                         DataFusionError::Execution(format!(
-                            "Failed to create odbc connection to mdb: {e:?}"
+                            "Failed to create odbc connection to access: {e:?}"
                         ))
                     })?;
                 let conn = Arc::new(Mutex::new(connection));
@@ -173,7 +155,7 @@ impl Pool for MdbPool {
         };
 
         self.connections.fetch_add(1, Ordering::SeqCst);
-        Ok(Arc::new(MdbConnection {
+        Ok(Arc::new(AccessConnection {
             conn,
             pool_connections: self.connections.clone(),
         }))
@@ -189,29 +171,32 @@ impl Pool for MdbPool {
 }
 
 #[derive(Debug)]
-pub struct MdbConnection {
+pub struct AccessConnection {
     conn: Arc<Mutex<odbc_api::Connection<'static>>>,
     pool_connections: Arc<AtomicUsize>,
 }
 
-impl Drop for MdbConnection {
+impl Drop for AccessConnection {
     fn drop(&mut self) {
         self.pool_connections.fetch_sub(1, Ordering::SeqCst);
     }
 }
 #[async_trait::async_trait]
-impl Connection for MdbConnection {
+impl Connection for AccessConnection {
     async fn infer_schema(&self, source: &RemoteSource) -> DFResult<RemoteSchemaRef> {
-        if matches!(source, RemoteSource::Command(SourceCommand::ListMdbTables)) {
-            return Ok(Arc::new(list_tables_remote_schema()));
+        if let RemoteSource::Command(cmd) = source {
+            return Err(DataFusionError::NotImplemented(format!(
+                "{cmd:?} is only supported for mdb sources; an .accdb file is queried \
+                 through its MSysObjects catalog table"
+            )));
         }
 
-        let sql = RemoteDbType::Mdb.limit_1_query_if_possible(source)?;
-        debug!("[remote-table] inferring mdb schema with: {sql}");
+        let sql = RemoteDbType::Access.limit_1_query_if_possible(source)?;
+        debug!("[remote-table] inferring access schema with: {sql}");
         let conn = self.conn.lock().await;
         let cursor_opt = conn.execute(&sql, (), None).map_err(|e| {
             DataFusionError::Plan(format!(
-                "Failed to execute query for schema inference on mdb: {e:?}, sql: {sql}"
+                "Failed to execute query for schema inference on access: {e:?}, sql: {sql}"
             ))
         })?;
         match cursor_opt {
@@ -234,16 +219,17 @@ impl Connection for MdbConnection {
         unparsed_filters: &[String],
         limit: Option<usize>,
     ) -> DFResult<SendableRecordBatchStream> {
-        if matches!(source, RemoteSource::Command(SourceCommand::ListMdbTables)) {
-            return self
-                .query_list_tables_impl(table_schema, projection, limit)
-                .await;
+        if let RemoteSource::Command(cmd) = source {
+            return Err(DataFusionError::NotImplemented(format!(
+                "{cmd:?} is only supported for mdb sources; an .accdb file is queried \
+                 through its MSysObjects catalog table"
+            )));
         }
 
         let projected_schema = project_schema(&table_schema, projection)?;
 
-        let sql = RemoteDbType::Mdb.rewrite_query(source, unparsed_filters, limit)?;
-        debug!("[remote-table] executing mdb query: {sql}");
+        let sql = RemoteDbType::Access.rewrite_query(source, unparsed_filters, limit)?;
+        debug!("[remote-table] executing access query: {sql}");
 
         let chunk_size = conn_options.stream_chunk_size();
         let conn = Arc::clone(&self.conn);
@@ -259,12 +245,12 @@ impl Connection for MdbConnection {
                 .execute(&sql, (), None)
                 .map_err(|e| {
                     DataFusionError::Execution(format!(
-                        "Failed to execute query on mdb: {e:?}, sql: {sql}"
+                        "Failed to execute query on access: {e:?}, sql: {sql}"
                     ))
                 })?
                 .ok_or_else(|| {
                     DataFusionError::Execution(format!(
-                        "No result set returned for mdb query: {sql}"
+                        "No result set returned for access query: {sql}"
                     ))
                 })?;
 
@@ -296,7 +282,9 @@ impl Connection for MdbConnection {
                     let batch =
                         finish_batch(builders, &table_schema, projection.as_ref(), row_count)?;
                     batch_tx.blocking_send(batch).map_err(|e| {
-                        DataFusionError::Execution(format!("Failed to send batch from mdb: {e:?}"))
+                        DataFusionError::Execution(format!(
+                            "Failed to send batch from access: {e:?}"
+                        ))
                     })?;
                 }
                 if exhausted {
@@ -316,7 +304,7 @@ impl Connection for MdbConnection {
                 Ok(Ok(())) => {},
                 Ok(Err(e)) => yield Err(e),
                 Err(e) => yield Err(DataFusionError::Execution(format!(
-                    "Failed to execute ODBC query on mdb: {e}"
+                    "Failed to execute ODBC query on access: {e}"
                 ))),
             }
         };
@@ -336,7 +324,7 @@ impl Connection for MdbConnection {
         _batch: RecordBatch,
     ) -> DFResult<usize> {
         Err(DataFusionError::Execution(
-            "Insert operation is not supported for mdb".to_string(),
+            "Insert operation is not supported for access".to_string(),
         ))
     }
 
@@ -346,9 +334,11 @@ impl Connection for MdbConnection {
         source: &RemoteSource,
         unparsed_filters: &[String],
     ) -> DFResult<Option<usize>> {
-        if matches!(source, RemoteSource::Command(SourceCommand::ListMdbTables)) {
-            let tables = self.list_tables().await?;
-            return Ok(Some(tables.len()));
+        if let RemoteSource::Command(cmd) = source {
+            return Err(DataFusionError::NotImplemented(format!(
+                "{cmd:?} is only supported for mdb sources; an .accdb file is queried \
+                 through its MSysObjects catalog table"
+            )));
         }
 
         let db_type = conn_options.db_type();
@@ -357,10 +347,10 @@ impl Connection for MdbConnection {
         } else {
             RemoteSource::Query(db_type.rewrite_query(source, unparsed_filters, None)?)
         };
-        // MDB only supports COUNT on table sources
+        // Access only supports COUNT on table sources
         if let RemoteSource::Table(table) = &source {
             let count_query = db_type.select_all_query(table);
-            debug!("[remote-table] fetching MDB row count with query: {count_query}");
+            debug!("[remote-table] fetching Access row count with query: {count_query}");
             let row_count = self.fetch_table_row_count(&count_query).await?;
             Ok(Some(row_count))
         } else {
@@ -369,7 +359,7 @@ impl Connection for MdbConnection {
     }
 }
 
-impl MdbConnection {
+impl AccessConnection {
     async fn fetch_table_row_count(&self, count_query: &str) -> DFResult<usize> {
         let conn = Arc::clone(&self.conn);
         let count_query = count_query.to_string();
@@ -384,12 +374,12 @@ impl MdbConnection {
                 .execute(&count_query, (), None)
                 .map_err(|e| {
                     DataFusionError::Execution(format!(
-                        "Failed to execute MDB row count query: {e:?}, sql: {count_query}"
+                        "Failed to execute Access row count query: {e:?}, sql: {count_query}"
                     ))
                 })?
                 .ok_or_else(|| {
                     DataFusionError::Execution(format!(
-                        "No result set for MDB row count query: {count_query}"
+                        "No result set for Access row count query: {count_query}"
                     ))
                 })?;
 
@@ -402,7 +392,7 @@ impl MdbConnection {
                     Ok(None) => break,
                     Err(e) => {
                         return Err(DataFusionError::Execution(format!(
-                            "Failed fetching MDB row count: {e}"
+                            "Failed fetching Access row count: {e}"
                         )));
                     }
                 }
@@ -412,126 +402,7 @@ impl MdbConnection {
         })
         .await
         .map_err(|e| {
-            DataFusionError::Execution(format!("Failed to join MDB row count task: {e}"))
+            DataFusionError::Execution(format!("Failed to join Access row count task: {e}"))
         })?
-    }
-
-    /// Core: query MSysObjects on an already-locked connection.
-    /// Returns (table_name, table_type), system tables filtered out.
-    ///
-    /// Queries the MDB system table directly via `conn.execute()` instead of
-    /// the ODBC catalog function `SQLTables`, avoiding the need for unsafe
-    /// `CursorImpl::new`. MSysObjects.Type values: 1=local table, 4=linked
-    /// ODBC, 5=query/view, 6=linked table.
-    fn list_tables_sync(conn: &odbc_api::Connection<'_>) -> DFResult<Vec<(String, String)>> {
-        let mut cursor = conn
-            .execute(
-                "SELECT Name, Type FROM MSysObjects WHERE Type=1 OR Type=4 OR Type=5 OR Type=6",
-                (),
-                None,
-            )
-            .map_err(|e| {
-                DataFusionError::Execution(format!("Failed to query MSysObjects on mdb: {e:?}"))
-            })?
-            .ok_or_else(|| {
-                DataFusionError::Execution("No result from MSysObjects query".to_string())
-            })?;
-
-        let mut tables = Vec::new();
-        let mut name_buf: Vec<u8> = Vec::new();
-        let mut type_buf: Vec<u8> = Vec::new();
-
-        loop {
-            match cursor.next_row() {
-                Ok(Some(mut row)) => {
-                    // Column 1 = Name
-                    name_buf.clear();
-                    if !row.get_text(1, &mut name_buf).unwrap_or(false) {
-                        continue;
-                    }
-                    let table_name = String::from_utf8_lossy(&name_buf).into_owned();
-
-                    // Filter system/internal tables
-                    if table_name.starts_with("MSys") || table_name.starts_with("~") {
-                        continue;
-                    }
-
-                    // Column 2 = Type: 5 = query/view
-                    type_buf.clear();
-                    let is_view = row.get_text(2, &mut type_buf).unwrap_or(false)
-                        && String::from_utf8_lossy(&type_buf).trim() == "5";
-
-                    let display_type = if is_view { "View" } else { "Table" };
-                    tables.push((table_name, display_type.to_string()));
-                }
-                Ok(None) => break,
-                Err(e) => {
-                    return Err(DataFusionError::External(Box::new(e)));
-                }
-            }
-        }
-
-        debug!("[remote-table] list_tables found {} tables", tables.len());
-        Ok(tables)
-    }
-
-    /// List user tables in the MDB file using the cached ODBC connection.
-    pub async fn list_tables(&self) -> DFResult<Vec<(String, String)>> {
-        let conn = Arc::clone(&self.conn);
-        tokio::task::spawn_blocking(move || {
-            let handle = Handle::current();
-            let guard = handle.block_on(async { conn.lock().await });
-            Self::list_tables_sync(&guard)
-        })
-        .await
-        .map_err(|e| DataFusionError::Execution(format!("Failed to join list_tables task: {e}")))?
-    }
-
-    /// Build a RecordBatch stream from the in-memory table list.
-    async fn query_list_tables_impl(
-        &self,
-        table_schema: SchemaRef,
-        projection: Option<&Vec<usize>>,
-        limit: Option<usize>,
-    ) -> DFResult<SendableRecordBatchStream> {
-        let mut tables = self.list_tables().await?;
-        if let Some(lim) = limit {
-            tables.truncate(lim);
-        }
-
-        let mut name_builder = StringBuilder::new();
-        let mut type_builder = StringBuilder::new();
-        for (name, typ) in &tables {
-            name_builder.append_value(name);
-            type_builder.append_value(typ);
-        }
-
-        let full_schema = Arc::new(list_tables_remote_schema().to_arrow_schema());
-        let batch = RecordBatch::try_new(
-            full_schema.clone(),
-            vec![
-                Arc::new(name_builder.finish()),
-                Arc::new(type_builder.finish()),
-            ],
-        )?;
-
-        let projected_schema = project_schema(&table_schema, projection)?;
-        let output_batch = match projection {
-            Some(indices) => {
-                let columns: Vec<ArrayRef> =
-                    indices.iter().map(|&i| batch.column(i).clone()).collect();
-                RecordBatch::try_new(projected_schema.clone(), columns)?
-            }
-            None => batch,
-        };
-
-        let output_stream = async_stream::stream! {
-            yield Ok(output_batch);
-        };
-
-        Ok(Box::pin(RecordBatchStreamAdapter::new(
-            projected_schema,
-            output_stream,
-        )))
     }
 }

--- a/remote-table/src/connection/access/row.rs
+++ b/remote-table/src/connection/access/row.rs
@@ -1,0 +1,338 @@
+use crate::DFResult;
+use arrow::array::{
+    ArrayRef, BinaryBuilder, BinaryViewBuilder, BooleanBuilder, Date32Builder, Decimal128Builder,
+    FixedSizeBinaryBuilder, Float32Builder, Float64Builder, Int8Builder, Int16Builder,
+    Int32Builder, Int64Builder, RecordBatch, RecordBatchOptions, StringBuilder, StringViewBuilder,
+    Time64MicrosecondBuilder, TimestampMicrosecondBuilder,
+};
+use arrow::datatypes::{DataType, Date32Type, SchemaRef, TimeUnit};
+use chrono::{NaiveDate, NaiveTime, Timelike};
+use datafusion_common::DataFusionError;
+use datafusion_common::project_schema;
+use odbc_api::decimal_text_to_i128;
+
+use crate::connection::projections_contains;
+
+macro_rules! read_data {
+    ($builder:expr, $field:expr, $builder_ty:ty, $row:expr, $col_idx:expr, $value_ty:ty, $convert:expr) => {{
+        let builder = $builder
+            .as_any_mut()
+            .downcast_mut::<$builder_ty>()
+            .unwrap_or_else(|| {
+                panic!(
+                    "Failed to downcast builder to {} for {:?}",
+                    stringify!($builder_ty),
+                    $field,
+                )
+            });
+        let mut value = odbc_api::Nullable::<$value_ty>::null();
+        $row.get_data($col_idx, &mut value).map_err(|e| {
+            DataFusionError::Execution(format!("Failed to get value for field {:?}: {e:?}", $field))
+        })?;
+        let value = value.into_opt();
+        match value {
+            Some(v) => builder.append_value($convert(v)?),
+            None => builder.append_null(),
+        }
+    }};
+}
+
+macro_rules! read_text {
+    ($builder:expr, $field:expr, $builder_ty:ty, $row:expr, $col_idx:expr, $buf:expr, $convert:expr) => {{
+        let builder = $builder
+            .as_any_mut()
+            .downcast_mut::<$builder_ty>()
+            .unwrap_or_else(|| {
+                panic!(
+                    "Failed to downcast builder to {} for {:?}",
+                    stringify!($builder_ty),
+                    $field,
+                )
+            });
+        $buf.clear();
+        let is_not_null = $row.get_text($col_idx, $buf).map_err(|e| {
+            DataFusionError::Execution(format!("Failed to get value for field {:?}: {e:?}", $field))
+        })?;
+        if is_not_null {
+            // mdbtools returns text in the file's code page (CP1252/CP936/etc.),
+            // not UTF-8. from_utf8_lossy keeps the printable bytes and substitutes
+            // U+FFFD for invalid ones, so non-ASCII cells don't abort the batch.
+            let value = String::from_utf8_lossy($buf).into_owned();
+            builder.append_value($convert(value)?);
+        } else {
+            builder.append_null();
+        }
+    }};
+}
+
+pub(super) fn append_row_to_builders(
+    builders: &mut [Box<dyn arrow::array::ArrayBuilder>],
+    mut row: odbc_api::CursorRow,
+    table_schema: &SchemaRef,
+) -> DFResult<()> {
+    // Reuse one Vec per ODBC cell type across all columns/rows in this call so
+    // we don't allocate a new buffer for every cell.
+    let mut text_buf: Vec<u8> = Vec::new();
+    let mut binary_buf: Vec<u8> = Vec::new();
+    for (idx, field) in table_schema.fields().iter().enumerate() {
+        let builder = &mut builders[idx];
+        let odbc_col_idx = (idx + 1) as u16;
+        match field.data_type() {
+            DataType::Boolean => {
+                read_data!(
+                    builder,
+                    field,
+                    BooleanBuilder,
+                    row,
+                    odbc_col_idx,
+                    odbc_api::Bit,
+                    |v: odbc_api::Bit| { Ok::<_, DataFusionError>(v.as_bool()) }
+                );
+            }
+            DataType::Int8 => {
+                read_data!(
+                    builder,
+                    field,
+                    Int8Builder,
+                    row,
+                    odbc_col_idx,
+                    i8,
+                    |v: i8| Ok::<_, DataFusionError>(v)
+                );
+            }
+            DataType::Int16 => {
+                read_data!(
+                    builder,
+                    field,
+                    Int16Builder,
+                    row,
+                    odbc_col_idx,
+                    i16,
+                    |v: i16| Ok::<_, DataFusionError>(v)
+                );
+            }
+            DataType::Int32 => {
+                read_data!(
+                    builder,
+                    field,
+                    Int32Builder,
+                    row,
+                    odbc_col_idx,
+                    i32,
+                    |v: i32| Ok::<_, DataFusionError>(v)
+                );
+            }
+            DataType::Int64 => {
+                read_data!(
+                    builder,
+                    field,
+                    Int64Builder,
+                    row,
+                    odbc_col_idx,
+                    i64,
+                    |v: i64| Ok::<_, DataFusionError>(v)
+                );
+            }
+            DataType::Float32 => {
+                read_data!(
+                    builder,
+                    field,
+                    Float32Builder,
+                    row,
+                    odbc_col_idx,
+                    f32,
+                    |v: f32| Ok::<_, DataFusionError>(v)
+                );
+            }
+            DataType::Float64 => {
+                read_data!(
+                    builder,
+                    field,
+                    Float64Builder,
+                    row,
+                    odbc_col_idx,
+                    f64,
+                    |v: f64| Ok::<_, DataFusionError>(v)
+                );
+            }
+            DataType::Decimal128(_precision, scale) => {
+                read_text!(
+                    builder,
+                    field,
+                    Decimal128Builder,
+                    row,
+                    odbc_col_idx,
+                    &mut text_buf,
+                    |v: String| {
+                        Ok::<_, DataFusionError>(decimal_text_to_i128(
+                            v.as_bytes(),
+                            *scale as usize,
+                        ))
+                    }
+                );
+            }
+            DataType::Utf8 => {
+                read_text!(
+                    builder,
+                    field,
+                    StringBuilder,
+                    row,
+                    odbc_col_idx,
+                    &mut text_buf,
+                    |v: String| Ok::<_, DataFusionError>(v)
+                );
+            }
+            DataType::Utf8View => {
+                read_text!(
+                    builder,
+                    field,
+                    StringViewBuilder,
+                    row,
+                    odbc_col_idx,
+                    &mut text_buf,
+                    |v: String| Ok::<_, DataFusionError>(v)
+                );
+            }
+            DataType::FixedSizeBinary(_) => {
+                let builder = builder
+                    .as_any_mut()
+                    .downcast_mut::<FixedSizeBinaryBuilder>()
+                    .unwrap_or_else(|| {
+                        panic!("Failed to downcast builder to FixedSizeBinaryBuilder for {field:?}")
+                    });
+                binary_buf.clear();
+                let is_not_null = row.get_binary(odbc_col_idx, &mut binary_buf).map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "Failed to get value for field {:?}: {e:?}",
+                        field
+                    ))
+                })?;
+                if is_not_null {
+                    builder.append_value(&binary_buf)?;
+                } else {
+                    builder.append_null();
+                }
+            }
+            DataType::Binary => {
+                let builder = builder
+                    .as_any_mut()
+                    .downcast_mut::<BinaryBuilder>()
+                    .unwrap_or_else(|| {
+                        panic!("Failed to downcast builder to BinaryBuilder for {field:?}")
+                    });
+                binary_buf.clear();
+                let is_not_null = row.get_binary(odbc_col_idx, &mut binary_buf).map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "Failed to get value for field {:?}: {e:?}",
+                        field
+                    ))
+                })?;
+                if is_not_null {
+                    builder.append_value(&binary_buf);
+                } else {
+                    builder.append_null();
+                }
+            }
+            DataType::BinaryView => {
+                let builder = builder
+                    .as_any_mut()
+                    .downcast_mut::<BinaryViewBuilder>()
+                    .unwrap_or_else(|| {
+                        panic!("Failed to downcast builder to BinaryViewBuilder for {field:?}")
+                    });
+                binary_buf.clear();
+                let is_not_null = row.get_binary(odbc_col_idx, &mut binary_buf).map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "Failed to get value for field {:?}: {e:?}",
+                        field
+                    ))
+                })?;
+                if is_not_null {
+                    builder.append_value(&binary_buf);
+                } else {
+                    builder.append_null();
+                }
+            }
+            DataType::Timestamp(TimeUnit::Microsecond, _) => {
+                read_data!(
+                    builder,
+                    field,
+                    TimestampMicrosecondBuilder,
+                    row,
+                    odbc_col_idx,
+                    odbc_api::sys::Timestamp,
+                    |v| { crate::connection::us_since_epoch(&v) }
+                );
+            }
+            DataType::Time64(TimeUnit::Microsecond) => {
+                read_text!(
+                    builder,
+                    field,
+                    Time64MicrosecondBuilder,
+                    row,
+                    odbc_col_idx,
+                    &mut text_buf,
+                    |value: String| {
+                        let nt = NaiveTime::parse_from_str(&value, "%H:%M:%S%.f").map_err(|e| {
+                            DataFusionError::Execution(format!("Failed to parse time: {e:?}"))
+                        })?;
+                        Ok::<_, DataFusionError>(
+                            nt.num_seconds_from_midnight() as i64 * 1_000_000
+                                + (nt.nanosecond() / 1000) as i64,
+                        )
+                    }
+                );
+            }
+            DataType::Date32 => {
+                read_data!(
+                    builder,
+                    field,
+                    Date32Builder,
+                    row,
+                    odbc_col_idx,
+                    odbc_api::sys::Date,
+                    |value: odbc_api::sys::Date| {
+                        let date = NaiveDate::from_ymd_opt(
+                            value.year as i32,
+                            value.month as u32,
+                            value.day as u32,
+                        )
+                        .ok_or_else(|| {
+                            DataFusionError::Execution(format!("Invalid date: {value:?}"))
+                        })?;
+                        Ok::<_, DataFusionError>(Date32Type::from_naive_date(date))
+                    }
+                );
+            }
+            _ => {
+                return Err(DataFusionError::NotImplemented(format!(
+                    "Unsupported field type for access row conversion: {field:?}"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn finish_batch(
+    builders: Vec<Box<dyn arrow::array::ArrayBuilder>>,
+    table_schema: &SchemaRef,
+    projection: Option<&Vec<usize>>,
+    row_count: usize,
+) -> DFResult<RecordBatch> {
+    let projected_schema = project_schema(table_schema, projection)?;
+
+    let arrays = builders
+        .into_iter()
+        .enumerate()
+        .filter(|(idx, _)| projections_contains(projection, *idx))
+        .map(|(_, mut builder)| builder.finish())
+        .collect::<Vec<ArrayRef>>();
+
+    let options = RecordBatchOptions::new().with_row_count(Some(row_count));
+    Ok(RecordBatch::try_new_with_options(
+        projected_schema,
+        arrays,
+        &options,
+    )?)
+}

--- a/remote-table/src/connection/access/schema.rs
+++ b/remote-table/src/connection/access/schema.rs
@@ -1,0 +1,81 @@
+use crate::AccessType;
+use crate::DFResult;
+use crate::RemoteField;
+use crate::RemoteSchema;
+use crate::RemoteType;
+use datafusion_common::DataFusionError;
+use odbc_api::CursorImpl;
+use odbc_api::ResultSetMetadata;
+use odbc_api::handles::{AsStatementRef, ColumnDescription, Statement, StatementImpl};
+
+pub(super) fn build_remote_schema(mut cursor: CursorImpl<StatementImpl>) -> DFResult<RemoteSchema> {
+    let col_count = cursor
+        .num_result_cols()
+        .map_err(|e| DataFusionError::External(Box::new(e)))? as u16;
+    let mut remote_fields = vec![];
+    for i in 1..=col_count {
+        // mdbtools' libmdbodbc.so doesn't fully support the higher-level
+        // SQLColAttribute wrappers (cursor.col_name / col_data_type /
+        // col_nullability return NoDiagnostics), so we go through the
+        // low-level SQLDescribeCol path.
+        let mut col_desc = ColumnDescription::default();
+        let describe_result = cursor.as_stmt_ref().describe_col(i, &mut col_desc);
+        if describe_result.is_err() {
+            return Err(DataFusionError::Plan(format!(
+                "describe_col failed for column {i} on access"
+            )));
+        }
+        // mdbtools is the only driver this backend talks to and it reports
+        // column names in the file's code page (CP1252/CP936/etc.), not UTF-8.
+        // from_utf8_lossy keeps the printable bytes and substitutes U+FFFD for
+        // the rest, so non-ASCII names don't abort a batch.
+        let col_name = String::from_utf8_lossy(&col_desc.name).into_owned();
+        let col_nullable = col_desc.nullability.could_be_nullable();
+
+        let remote_type = RemoteType::Access(access_type_to_remote_type(col_desc.data_type)?);
+        remote_fields.push(RemoteField::new(col_name, remote_type, col_nullable));
+    }
+
+    Ok(RemoteSchema::new(remote_fields))
+}
+
+fn access_type_to_remote_type(data_type: odbc_api::DataType) -> DFResult<AccessType> {
+    match data_type {
+        odbc_api::DataType::Bit => Ok(AccessType::Bit),
+        odbc_api::DataType::TinyInt => Ok(AccessType::TinyInt),
+        odbc_api::DataType::SmallInt => Ok(AccessType::SmallInt),
+        odbc_api::DataType::Integer => Ok(AccessType::Integer),
+        odbc_api::DataType::Real => Ok(AccessType::Real),
+        odbc_api::DataType::Double => Ok(AccessType::Double),
+        odbc_api::DataType::Numeric { .. } | odbc_api::DataType::Decimal { .. } => {
+            Ok(AccessType::Currency)
+        }
+        odbc_api::DataType::Char { length } | odbc_api::DataType::WVarchar { length } => {
+            Ok(AccessType::Text(length.map(|l| l.get() as u16)))
+        }
+        odbc_api::DataType::Varchar { length } => {
+            Ok(AccessType::Text(length.map(|l| l.get() as u16)))
+        }
+        odbc_api::DataType::LongVarchar { .. } | odbc_api::DataType::WLongVarchar { .. } => {
+            Ok(AccessType::Memo)
+        }
+        odbc_api::DataType::Binary { length } | odbc_api::DataType::Varbinary { length } => {
+            Ok(AccessType::Binary(length.map(|l| l.get() as u16)))
+        }
+        odbc_api::DataType::LongVarbinary { .. } => Ok(AccessType::OleObject),
+        odbc_api::DataType::Timestamp { .. } => Ok(AccessType::DateTime),
+        odbc_api::DataType::Date => Ok(AccessType::Date),
+        odbc_api::DataType::Time { .. } => Ok(AccessType::Time),
+        odbc_api::DataType::WChar { length } => {
+            Ok(AccessType::Text(length.map(|l| l.get() as u16)))
+        }
+        odbc_api::DataType::Other { data_type, .. }
+            if data_type == odbc_api::sys::SqlDataType::EXT_GUID =>
+        {
+            Ok(AccessType::Guid)
+        }
+        _ => Err(DataFusionError::Execution(format!(
+            "Unsupported Access type: {data_type:?}"
+        ))),
+    }
+}

--- a/remote-table/src/connection/mod.rs
+++ b/remote-table/src/connection/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "access")]
+mod access;
 #[cfg(feature = "dm")]
 mod dm;
 #[cfg(feature = "gaussdb")]
@@ -14,6 +16,8 @@ mod postgres;
 #[cfg(feature = "sqlite")]
 mod sqlite;
 
+#[cfg(feature = "access")]
+pub use access::*;
 #[cfg(feature = "dm")]
 pub use dm::*;
 #[cfg(feature = "gaussdb")]
@@ -44,7 +48,7 @@ use log::debug;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-#[cfg(any(feature = "dm", feature = "mdb"))]
+#[cfg(any(feature = "dm", feature = "mdb", feature = "access"))]
 pub static ODBC_ENV: std::sync::OnceLock<odbc_api::Environment> = std::sync::OnceLock::new();
 
 #[async_trait::async_trait]
@@ -208,6 +212,19 @@ pub async fn connect(options: &ConnectionOptions) -> DFResult<Arc<dyn Pool>> {
                 ))
             }
         }
+        ConnectionOptions::Access(options) => {
+            #[cfg(feature = "access")]
+            {
+                let pool = connect_access(options)?;
+                Ok(Arc::new(pool))
+            }
+            #[cfg(not(feature = "access"))]
+            {
+                Err(DataFusionError::Internal(
+                    "Please enable the access feature".to_string(),
+                ))
+            }
+        }
         ConnectionOptions::GaussDB(options) => {
             #[cfg(feature = "gaussdb")]
             {
@@ -231,14 +248,18 @@ pub enum RemoteDbType {
     Oracle,
     Sqlite,
     Dm,
+    /// Microsoft Access `.mdb` files (Jet 3 / Jet 4 engine).
     Mdb,
+    /// Microsoft Access `.accdb` files (ACE engine). Every code path that talks
+    /// to the database is shared with [`RemoteDbType::Mdb`].
+    Access,
     GaussDB,
 }
 
 impl RemoteDbType {
     pub(crate) fn support_rewrite_with_filters_limit(&self, source: &RemoteSource) -> bool {
         match self {
-            RemoteDbType::Mdb => matches!(source, RemoteSource::Table(_)),
+            RemoteDbType::Mdb | RemoteDbType::Access => matches!(source, RemoteSource::Table(_)),
             _ => match source {
                 RemoteSource::Table(_) => true,
                 RemoteSource::Query(query) => query.trim()[0..6].eq_ignore_ascii_case("select"),
@@ -260,7 +281,7 @@ impl RemoteDbType {
             RemoteDbType::Dm => Err(DataFusionError::NotImplemented(
                 "Dm unparser not implemented".to_string(),
             )),
-            RemoteDbType::Mdb => Ok(Unparser::new(&PostgreSqlDialect {})),
+            RemoteDbType::Mdb | RemoteDbType::Access => Ok(Unparser::new(&PostgreSqlDialect {})),
         }
     }
 
@@ -293,7 +314,7 @@ impl RemoteDbType {
                         self.select_all_query(table)
                     ))
                 }
-                RemoteDbType::Mdb => {
+                RemoteDbType::Mdb | RemoteDbType::Access => {
                     let where_clause = if unparsed_filters.is_empty() {
                         "".to_string()
                     } else {
@@ -339,6 +360,7 @@ impl RemoteDbType {
                 | RemoteDbType::Sqlite
                 | RemoteDbType::Dm
                 | RemoteDbType::Mdb
+                | RemoteDbType::Access
                 | RemoteDbType::GaussDB => {
                     let where_clause = if unparsed_filters.is_empty() {
                         "".to_string()
@@ -396,7 +418,7 @@ impl RemoteDbType {
             RemoteDbType::Mysql => {
                 format!("`{identifier}`")
             }
-            RemoteDbType::Mdb => {
+            RemoteDbType::Mdb | RemoteDbType::Access => {
                 format!("[{identifier}]")
             }
         }
@@ -426,7 +448,7 @@ impl RemoteDbType {
             RemoteDbType::Oracle | RemoteDbType::Dm => {
                 format!("HEXTORAW('{}')", hex::encode(value))
             }
-            RemoteDbType::Mdb => format!("X'{}'", hex::encode(value)),
+            RemoteDbType::Mdb | RemoteDbType::Access => format!("X'{}'", hex::encode(value)),
         }
     }
 
@@ -438,6 +460,7 @@ impl RemoteDbType {
             | RemoteDbType::Sqlite
             | RemoteDbType::Dm
             | RemoteDbType::Mdb
+            | RemoteDbType::Access
             | RemoteDbType::GaussDB => {
                 format!("SELECT * FROM {}", self.sql_table_name(table_identifiers))
             }
@@ -456,7 +479,7 @@ impl RemoteDbType {
             return None;
         }
         match self {
-            RemoteDbType::Mdb => None,
+            RemoteDbType::Mdb | RemoteDbType::Access => None,
             _ => match source {
                 RemoteSource::Table(table) => Some(format!(
                     "SELECT COUNT(1) FROM {}",
@@ -471,7 +494,7 @@ impl RemoteDbType {
                         Some(format!("SELECT COUNT(1) FROM ({query}) AS __subquery"))
                     }
                     RemoteDbType::Oracle => Some(format!("SELECT COUNT(1) FROM ({query})")),
-                    RemoteDbType::Mdb => unreachable!(),
+                    RemoteDbType::Mdb | RemoteDbType::Access => unreachable!(),
                 },
                 RemoteSource::Command(_) => None,
             },
@@ -529,7 +552,7 @@ fn just_deref<T: Copy>(t: &T) -> DFResult<T> {
     Ok(*t)
 }
 
-#[cfg(any(feature = "dm", feature = "mdb"))]
+#[cfg(any(feature = "dm", feature = "mdb", feature = "access"))]
 mod odbc_utils {
     //! Shared ODBC helpers used by both the dm and mdb backends.
 
@@ -574,5 +597,5 @@ mod odbc_utils {
             .ok_or_else(|| DataFusionError::Execution(format!("Invalid timestamp: {value:?}")))
     }
 }
-#[cfg(any(feature = "dm", feature = "mdb"))]
+#[cfg(any(feature = "dm", feature = "mdb", feature = "access"))]
 pub(crate) use odbc_utils::*;

--- a/remote-table/src/connection/options.rs
+++ b/remote-table/src/connection/options.rs
@@ -1,6 +1,7 @@
 use crate::RemoteDbType;
 use derive_getters::Getters;
 use derive_with::With;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -11,7 +12,10 @@ pub enum ConnectionOptions {
     Mysql(MysqlConnectionOptions),
     Sqlite(SqliteConnectionOptions),
     Dm(DmConnectionOptions),
+    /// Microsoft Access `.mdb` files (Jet engine).
     Mdb(MdbConnectionOptions),
+    /// Microsoft Access `.accdb` files (ACE engine).
+    Access(AccessConnectionOptions),
     GaussDB(GaussDBConnectionOptions),
 }
 
@@ -24,6 +28,7 @@ impl ConnectionOptions {
             ConnectionOptions::Sqlite(options) => options.stream_chunk_size,
             ConnectionOptions::Dm(options) => options.stream_chunk_size,
             ConnectionOptions::Mdb(options) => options.stream_chunk_size,
+            ConnectionOptions::Access(options) => options.stream_chunk_size,
             ConnectionOptions::GaussDB(options) => options.stream_chunk_size,
         }
     }
@@ -36,6 +41,7 @@ impl ConnectionOptions {
             ConnectionOptions::Sqlite(_) => RemoteDbType::Sqlite,
             ConnectionOptions::Dm(_) => RemoteDbType::Dm,
             ConnectionOptions::Mdb(_) => RemoteDbType::Mdb,
+            ConnectionOptions::Access(_) => RemoteDbType::Access,
             ConnectionOptions::GaussDB(_) => RemoteDbType::GaussDB,
         }
     }
@@ -54,6 +60,7 @@ impl ConnectionOptions {
             ConnectionOptions::Sqlite(options) => ConnectionOptions::Sqlite(options),
             ConnectionOptions::Dm(options) => ConnectionOptions::Dm(options),
             ConnectionOptions::Mdb(options) => ConnectionOptions::Mdb(options),
+            ConnectionOptions::Access(options) => ConnectionOptions::Access(options),
             ConnectionOptions::GaussDB(options) => ConnectionOptions::GaussDB(options),
         }
     }
@@ -252,10 +259,13 @@ pub struct MdbConnectionOptions {
     pub stream_chunk_size: usize,
     pub uid: Option<String>,
     pub pwd: Option<String>,
-    /// Extra `key=value;` fragments appended verbatim. Use this for driver-specific
-    /// parameters not covered by the typed fields (e.g. `SystemDB`, `Exclusive=1`,
-    /// `IMEX=1` for the Microsoft Access ODBC driver on Windows).
-    pub extra_params: Vec<(String, String)>,
+    /// ODBC connection attributes, appended as `;key=value`. Use this for
+    /// driver-specific parameters not covered by the typed fields (e.g.
+    /// `SystemDB`, `Exclusive=1`, `IMEX=1` for the Microsoft Access ODBC driver
+    /// on Windows). A map, because a connection string is a set of attributes:
+    /// the order of different keywords is not significant, and repeating a
+    /// keyword is driver-defined behaviour that this type does not express.
+    pub extra_params: HashMap<String, String>,
 }
 
 impl MdbConnectionOptions {
@@ -266,7 +276,7 @@ impl MdbConnectionOptions {
             stream_chunk_size: 2048,
             uid: None,
             pwd: None,
-            extra_params: Vec::new(),
+            extra_params: HashMap::new(),
         }
     }
 
@@ -277,7 +287,7 @@ impl MdbConnectionOptions {
             stream_chunk_size: 2048,
             uid: None,
             pwd: None,
-            extra_params: Vec::new(),
+            extra_params: HashMap::new(),
         }
     }
 
@@ -303,6 +313,76 @@ impl MdbConnectionOptions {
 impl From<MdbConnectionOptions> for ConnectionOptions {
     fn from(options: MdbConnectionOptions) -> Self {
         ConnectionOptions::Mdb(options)
+    }
+}
+
+/// Options for a Microsoft Access `.accdb` (ACE engine) source.
+///
+/// This is its own type, with its own fields, pool and connection handling;
+/// what it shares with [`MdbConnectionOptions`] is only the shape of the
+/// connection parameters, because both formats are read through the same ODBC
+/// driver.
+#[derive(Debug, Clone, With, Getters)]
+pub struct AccessConnectionOptions {
+    pub path: PathBuf,
+    pub driver: String,
+    pub stream_chunk_size: usize,
+    pub uid: Option<String>,
+    pub pwd: Option<String>,
+    /// ODBC connection attributes, appended as `;key=value`. Use this for
+    /// driver-specific parameters not covered by the typed fields (e.g.
+    /// `SystemDB`, `Exclusive=1`, `IMEX=1` for the Microsoft Access ODBC driver
+    /// on Windows). A map, because a connection string is a set of attributes:
+    /// the order of different keywords is not significant, and repeating a
+    /// keyword is driver-defined behaviour that this type does not express.
+    pub extra_params: HashMap<String, String>,
+}
+
+impl AccessConnectionOptions {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            driver: "MDBTools".to_string(),
+            stream_chunk_size: 2048,
+            uid: None,
+            pwd: None,
+            extra_params: HashMap::new(),
+        }
+    }
+
+    pub fn new_with_driver(path: PathBuf, driver: impl Into<String>) -> Self {
+        Self {
+            path,
+            driver: driver.into(),
+            stream_chunk_size: 2048,
+            uid: None,
+            pwd: None,
+            extra_params: HashMap::new(),
+        }
+    }
+
+    /// Build the ODBC connection string. The default `Driver={...};DBQ=...` form
+    /// works for the mdbtools (Linux) driver. For the Microsoft Access ODBC driver
+    /// on Windows, set `uid`/`pwd` or add entries to `extra_params` (e.g.
+    /// `SystemDB`, `Exclusive`, `IMEX`).
+    pub fn connection_string(&self) -> String {
+        let mut s = format!("Driver={{{}}};DBQ={}", self.driver, self.path.display());
+        if let Some(uid) = &self.uid {
+            s.push_str(&format!(";UID={uid}"));
+        }
+        if let Some(pwd) = &self.pwd {
+            s.push_str(&format!(";PWD={pwd}"));
+        }
+        for (k, v) in &self.extra_params {
+            s.push_str(&format!(";{k}={v}"));
+        }
+        s
+    }
+}
+
+impl From<AccessConnectionOptions> for ConnectionOptions {
+    fn from(options: AccessConnectionOptions) -> Self {
+        ConnectionOptions::Access(options)
     }
 }
 

--- a/remote-table/src/generated/prost.rs
+++ b/remote-table/src/generated/prost.rs
@@ -54,7 +54,7 @@ pub struct RemoteTableInsertExec {
 pub struct ConnectionOptions {
     #[prost(
         oneof = "connection_options::ConnectionOptions",
-        tags = "1, 2, 3, 4, 5, 6, 7"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8"
     )]
     pub connection_options: ::core::option::Option<connection_options::ConnectionOptions>,
 }
@@ -76,6 +76,9 @@ pub mod connection_options {
         Mdb(super::MdbConnectionOptions),
         #[prost(message, tag = "7")]
         Gaussdb(super::GaussDbConnectionOptions),
+        /// Microsoft Access .accdb (ACE engine).
+        #[prost(message, tag = "8")]
+        Access(super::AccessConnectionOptions),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -90,15 +93,29 @@ pub struct MdbConnectionOptions {
     pub uid: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(string, optional, tag = "5")]
     pub pwd: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(message, repeated, tag = "6")]
-    pub extra_params: ::prost::alloc::vec::Vec<MdbExtraParam>,
+    /// ODBC connection attributes passed through verbatim. Serialized in key
+    /// order so encoded plans are byte-stable.
+    #[prost(map = "string, string", tag = "6")]
+    pub extra_params:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
 }
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct MdbExtraParam {
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AccessConnectionOptions {
     #[prost(string, tag = "1")]
-    pub key: ::prost::alloc::string::String,
+    pub path: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub value: ::prost::alloc::string::String,
+    pub driver: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "3")]
+    pub stream_chunk_size: u32,
+    #[prost(string, optional, tag = "4")]
+    pub uid: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "5")]
+    pub pwd: ::core::option::Option<::prost::alloc::string::String>,
+    /// ODBC connection attributes passed through verbatim. Serialized in key
+    /// order so encoded plans are byte-stable.
+    #[prost(map = "string, string", tag = "6")]
+    pub extra_params:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct RemoteSource {
@@ -285,7 +302,7 @@ pub struct RemoteField {
 pub struct RemoteType {
     #[prost(
         oneof = "remote_type::Type",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 301, 302, 303, 304, 305, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619, 620, 621, 622, 623, 624, 625, 626, 627, 628, 629, 630, 631, 632"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 301, 302, 303, 304, 305, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 701, 702, 703, 704, 705, 706, 707, 708, 709, 710, 711, 712, 713, 714, 715, 601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619, 620, 621, 622, 623, 624, 625, 626, 627, 628, 629, 630, 631, 632"
     )]
     pub r#type: ::core::option::Option<remote_type::Type>,
 }
@@ -523,6 +540,36 @@ pub mod remote_type {
         MdbDate(super::Empty),
         #[prost(message, tag = "515")]
         MdbTime(super::Empty),
+        #[prost(message, tag = "701")]
+        AccessBit(super::Empty),
+        #[prost(message, tag = "702")]
+        AccessTinyInt(super::Empty),
+        #[prost(message, tag = "703")]
+        AccessSmallInt(super::Empty),
+        #[prost(message, tag = "704")]
+        AccessInteger(super::Empty),
+        #[prost(message, tag = "705")]
+        AccessReal(super::Empty),
+        #[prost(message, tag = "706")]
+        AccessDouble(super::Empty),
+        #[prost(message, tag = "707")]
+        AccessCurrency(super::Empty),
+        #[prost(message, tag = "708")]
+        AccessText(super::AccessText),
+        #[prost(message, tag = "709")]
+        AccessMemo(super::Empty),
+        #[prost(message, tag = "710")]
+        AccessBinary(super::AccessBinary),
+        #[prost(message, tag = "711")]
+        AccessOleObject(super::Empty),
+        #[prost(message, tag = "712")]
+        AccessGuid(super::Empty),
+        #[prost(message, tag = "713")]
+        AccessDateTime(super::Empty),
+        #[prost(message, tag = "714")]
+        AccessDate(super::Empty),
+        #[prost(message, tag = "715")]
+        AccessTime(super::Empty),
         #[prost(message, tag = "601")]
         GaussdbInt2(super::Empty),
         #[prost(message, tag = "602")]
@@ -591,6 +638,16 @@ pub mod remote_type {
 }
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct MdbText {
+    #[prost(uint32, optional, tag = "1")]
+    pub length: ::core::option::Option<u32>,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AccessText {
+    #[prost(uint32, optional, tag = "1")]
+    pub length: ::core::option::Option<u32>,
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AccessBinary {
     #[prost(uint32, optional, tag = "1")]
     pub length: ::core::option::Option<u32>,
 }

--- a/remote-table/src/lib.rs
+++ b/remote-table/src/lib.rs
@@ -28,8 +28,9 @@ pub(crate) type DFResult<T> = datafusion_common::Result<T>;
     feature = "sqlite",
     feature = "dm",
     feature = "mdb",
+    feature = "access",
     feature = "gaussdb",
 )))]
 compile_error!(
-    "At least one of the following features must be enabled: postgres, mysql, oracle, sqlite, dm, mdb, gaussdb"
+    "At least one of the following features must be enabled: postgres, mysql, oracle, sqlite, dm, mdb, access, gaussdb"
 );

--- a/remote-table/src/schema.rs
+++ b/remote-table/src/schema.rs
@@ -13,6 +13,7 @@ pub enum RemoteType {
     Sqlite(SqliteType),
     Dm(DmType),
     Mdb(MdbType),
+    Access(AccessType),
     GaussDB(GaussDBType),
 }
 
@@ -25,6 +26,7 @@ impl RemoteType {
             RemoteType::Sqlite(sqlite_type) => sqlite_type.to_arrow_type(),
             RemoteType::Dm(dm_type) => dm_type.to_arrow_type(),
             RemoteType::Mdb(mdb_type) => mdb_type.to_arrow_type(),
+            RemoteType::Access(access_type) => access_type.to_arrow_type(),
             RemoteType::GaussDB(gdb_type) => gdb_type.to_arrow_type(),
         }
     }
@@ -37,6 +39,7 @@ impl RemoteType {
             RemoteType::Sqlite(_) => RemoteDbType::Sqlite,
             RemoteType::Dm(_) => RemoteDbType::Dm,
             RemoteType::Mdb(_) => RemoteDbType::Mdb,
+            RemoteType::Access(_) => RemoteDbType::Access,
             RemoteType::GaussDB(_) => RemoteDbType::GaussDB,
         }
     }
@@ -490,6 +493,84 @@ impl MdbType {
     pub fn column_size(&self) -> Option<i32> {
         match self {
             MdbType::Text(len) | MdbType::Binary(len) => len.map(|l| l as i32),
+            _ => None,
+        }
+    }
+}
+
+/// Microsoft Access `.accdb` (ACE engine) type mapping.
+///
+/// Mirrors [`MdbType`] because the same ODBC driver reports the same column
+/// types for both file formats, but each backend keeps its own type enum so a
+/// column of an `.accdb` source is never described as an MDB type in schemas,
+/// plans or the remote table API.
+#[derive(Debug, Clone)]
+pub enum AccessType {
+    Bit,
+    TinyInt,
+    SmallInt,
+    Integer,
+    Real,
+    Double,
+    Currency,
+    Text(Option<u16>),
+    Memo,
+    Binary(Option<u16>),
+    OleObject,
+    Guid,
+    DateTime,
+    Date,
+    Time,
+}
+
+impl AccessType {
+    pub fn to_arrow_type(&self) -> DataType {
+        match self {
+            AccessType::Bit => DataType::Boolean,
+            AccessType::TinyInt => DataType::Int8,
+            AccessType::SmallInt => DataType::Int16,
+            AccessType::Integer => DataType::Int32,
+            AccessType::Real => DataType::Float32,
+            AccessType::Double => DataType::Float64,
+            AccessType::Currency => DataType::Decimal128(19, 4),
+            AccessType::Text(_) => DataType::Utf8,
+            AccessType::Memo => DataType::Utf8,
+            AccessType::Binary(_) => DataType::Binary,
+            AccessType::OleObject => DataType::Binary,
+            AccessType::Guid => DataType::FixedSizeBinary(16),
+            AccessType::DateTime => DataType::Timestamp(TimeUnit::Microsecond, None),
+            AccessType::Date => DataType::Date32,
+            AccessType::Time => DataType::Time64(TimeUnit::Microsecond),
+        }
+    }
+
+    /// Human-readable Access type name (e.g. "Long Integer", "Text (100)", "OLE")
+    pub fn type_name(&self) -> String {
+        match self {
+            AccessType::Bit => "Bit".to_string(),
+            AccessType::TinyInt => "Byte".to_string(),
+            AccessType::SmallInt => "Small Integer".to_string(),
+            AccessType::Integer => "Long Integer".to_string(),
+            AccessType::Real => "Real".to_string(),
+            AccessType::Double => "Double".to_string(),
+            AccessType::Currency => "Currency".to_string(),
+            AccessType::Text(Some(len)) => format!("Text ({})", len),
+            AccessType::Text(None) => "Text".to_string(),
+            AccessType::Memo => "Memo".to_string(),
+            AccessType::Binary(Some(len)) => format!("Binary ({})", len),
+            AccessType::Binary(None) => "Binary".to_string(),
+            AccessType::OleObject => "OLE".to_string(),
+            AccessType::Guid => "GUID".to_string(),
+            AccessType::DateTime => "DateTime".to_string(),
+            AccessType::Date => "Date".to_string(),
+            AccessType::Time => "Time".to_string(),
+        }
+    }
+
+    /// For Access column_size: return length for Text/Binary types, None otherwise
+    pub fn column_size(&self) -> Option<i32> {
+        match self {
+            AccessType::Text(len) | AccessType::Binary(len) => len.map(|l| l as i32),
             _ => None,
         }
     }

--- a/remote-table/src/table.rs
+++ b/remote-table/src/table.rs
@@ -18,7 +18,12 @@ use tokio::sync::OnceCell;
 
 #[derive(Debug, Clone)]
 pub enum SourceCommand {
-    /// List all user tables/views in an MDB file.
+    /// List all user tables/views in an `.mdb` (Jet engine) file.
+    ///
+    /// There is no equivalent for `.accdb` sources: an ACE file is queried with
+    /// the [`MSysObjects` catalog
+    /// table](https://learn.microsoft.com/en-us/office/client-developer/access/desktop-database-reference/msysobjects-system-table)
+    /// like any other source.
     ListMdbTables,
 }
 

--- a/remote-table/src/transform.rs
+++ b/remote-table/src/transform.rs
@@ -1,4 +1,4 @@
-use crate::{DFResult, MdbType, RemoteDbType, RemoteSchemaRef, RemoteType};
+use crate::{AccessType, DFResult, MdbType, RemoteDbType, RemoteSchemaRef, RemoteType};
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
 use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
@@ -50,8 +50,8 @@ impl dyn Transform {
 /// initial "row matches" value. Pushing such a predicate as `Exact` would drop
 /// no rows remotely and DataFusion would not filter them locally either, so the
 /// predicate is reported as `Inexact` to keep a local `FilterExec` in the plan.
-fn mdb_filter_needs_local_evaluation(filter: &Expr, args: TransformArgs) -> bool {
-    if !matches!(args.db_type, RemoteDbType::Mdb) {
+fn odbc_access_filter_needs_local_evaluation(filter: &Expr, args: TransformArgs) -> bool {
+    if !matches!(args.db_type, RemoteDbType::Mdb | RemoteDbType::Access) {
         return false;
     }
 
@@ -69,6 +69,9 @@ fn mdb_filter_needs_local_evaluation(filter: &Expr, args: TransformArgs) -> bool
                     RemoteType::Mdb(MdbType::Currency)
                         | RemoteType::Mdb(MdbType::Binary(_))
                         | RemoteType::Mdb(MdbType::OleObject)
+                        | RemoteType::Access(AccessType::Currency)
+                        | RemoteType::Access(AccessType::Binary(_))
+                        | RemoteType::Access(AccessType::OleObject)
                 )
             {
                 needs_local_evaluation = true;
@@ -112,7 +115,7 @@ impl Transform for DefaultTransform {
             .expect("won't fail");
 
         if pushdown == TableProviderFilterPushDown::Exact
-            && mdb_filter_needs_local_evaluation(filter, args)
+            && odbc_access_filter_needs_local_evaluation(filter, args)
         {
             return Ok(TableProviderFilterPushDown::Inexact);
         }


### PR DESCRIPTION
Adds `RemoteDbType::Access` / `ConnectionOptions::Access` next to the existing `Mdb`, so `.accdb` (ACE engine) sources are declared as their own remote database.

## A standalone backend

`remote-table/src/connection/access` is an independent implementation: its own pool, connection, row decoding, schema inference, connection cache, cache key and connection string. It imports nothing from the mdb backend, and `connection/mdb` is byte-identical to master. The two only have the ODBC driver they both talk to in common.

| | MDB (`.mdb`, Jet) | Access (`.accdb`, ACE) |
|---|---|---|
| database type | `RemoteDbType::Mdb` | `RemoteDbType::Access` |
| options | `MdbConnectionOptions` | `AccessConnectionOptions` (own fields, builders, `connection_string()`) |
| pool | `MdbPool` + `MDB_CONN_CACHE` + `MdbConnectionCacheKey` | `AccessPool` + `ACCESS_CONN_CACHE` + `AccessConnectionCacheKey` |
| connection | `MdbConnection` | `AccessConnection` |
| row decoding / schema | `connection/mdb/{row,schema}.rs` | `connection/access/{row,schema}.rs` |
| column types | `MdbType`, `RemoteType::Mdb` | `AccessType`, `RemoteType::Access` |
| list-tables command | `SourceCommand::ListMdbTables` | none, see below |
| cargo feature | `mdb` | `access` |

The physical plan follows: the database type travels in its own `AccessConnectionOptions` proto message (`access`, tag 8) and Access columns in their own `Access*` proto fields, so a serialization round trip keeps both.

## Listing tables

An ACE file has a real catalog table, so `Access` needs no command: `MSysObjects` is queried like any other source (`Type` 1 = local table, 5 = stored query), and the integration test does exactly that. Passing `SourceCommand::ListMdbTables` to an Access connection returns a `NotImplemented` error explaining this.

## `extra_params` is a map

`MdbConnectionOptions::extra_params` (existing, breaking change) and `AccessConnectionOptions::extra_params` are now `HashMap<String, String>` instead of a list of pairs, and the plan schema models them as `map<string, string>`.

- **Wire compatible**: a proto map is a repeated entry message with `key = 1, value = 2`, which is exactly what the previous `repeated MdbExtraParam` / `AccessExtraParam` fields were, so plans encoded by the old code still decode.
- **Attributes, not a list**: a connection string is a set of `key=value` attributes. The order of different keywords is not significant (measured: `DBQ=...;Driver={MDBTools}` connects as well as the reverse), and repeating a keyword has driver-defined effects (measured: with unixODBC + `libmdbodbc` the first occurrence wins), which this type deliberately does not express.
- The backend connection cache keys keep a `BTreeMap` copy of the map so they iterate and print in a stable order; the options and the wire format use `HashMap`, and nothing sorts.

## Fixture and tests

Adds `setup_accdb()`, which downloads the `ASampleDatabase.accdb` fixture (Access 2007, ACE12, 544,768 bytes) from the same pinned mdbtools/mdbtestdata commit as `nwind.mdb`; its documentation lives in `testdata/access/README.md`, and `testdata/mdb/README.md` is left untouched.

`integration-tests/tests/access.rs` (new target, added to CI together with an `access`-only build) mirrors the `.mdb` suite from `mdb.rs` against the ACE fixture, so the two backends have the same coverage: basic queries over table and query sources, limit pushdown, `count(*)` pushdown and the DataFusion aggregate path, empty projections, table/column type coverage, streaming with a one-row chunk size, filter pushdown for text and integer columns, the Currency column that needs local evaluation, listing tables and stored queries through `MSysObjects`, a plan serialization round trip, and pool state. 21 cases in total. 

## Verification

```
cargo test -p integration-tests --test access      # 21 passed
cargo test -p integration-tests --test mdb         # 23 passed
cargo fmt --all -- --check
cargo clippy --all -- -D warnings
cargo check -p datafusion-remote-table --no-default-features --features access
cargo check -p datafusion-remote-table --no-default-features --features mdb
cargo check -p datafusion-remote-table --all-features
```

Only the `mdb` and `access` integration targets were run locally; the other backends need their containers.
